### PR TITLE
fix: freeze a cell which is merged

### DIFF
--- a/packages/core/src/modules/toolbar.ts
+++ b/packages/core/src/modules/toolbar.ts
@@ -1437,8 +1437,14 @@ export function handleFreeze(ctx: Context, type: string) {
   const firstSelection = ctx.luckysheet_select_save?.[0];
   if (!firstSelection) return;
 
-  const { row_focus, column_focus } = firstSelection;
+  let { row_focus, column_focus } = firstSelection;
   if (!row_focus || !column_focus) return;
+
+  const m = ctx.config.merge?.[`${row_focus}_${column_focus}`];
+  if (m) {
+    row_focus = m.r + m.rs - 1;
+    column_focus = m.c + m.cs - 1;
+  }
 
   file.frozen = { type: "both", range: { row_focus, column_focus } };
   if (type === "freeze-row") {


### PR DESCRIPTION
###问题
* 如果冻结一个已经合并的单元格时，冻结的是这个单元格的左上格，但是从逻辑和显示都应该为右下格
* 所以重新算一下