### PR TITLE
fix:Edits cannot be coordinated when displaying comments

### DIFF
--- a/packages/react/src/components/SheetOverlay/ContentEditable.tsx
+++ b/packages/react/src/components/SheetOverlay/ContentEditable.tsx
@@ -27,6 +27,13 @@ class ContentEditable extends React.Component<ContentEditableProps> {
     }
   }
 
+  UNSAFE_componentWillUpdate() {
+    const { initialContent } = this.props;
+    if (initialContent && this.root) {
+      this.root.innerHTML = initialContent;
+    }
+  }
+
   emitChange() {
     const { onChange } = this.props;
     const html = this.root?.innerHTML;


### PR DESCRIPTION
1.bug：当批注为显示状态的时候，进行修改批注内容，不会协同。
2.此bug原因：ContentEditable组件没有进行更新。
3.解决方案：添加生命周期函数。