### PR TITLE
fix:An empty cell brush with a valued cell disappears

### DIFF
--- a/packages/core/src/modules/selection.ts
+++ b/packages/core/src/modules/selection.ts
@@ -436,7 +436,15 @@ export function pasteHandlerOfPaintModel(
               }
             }
           } else {
-            x[c] = value;
+            if (x[c]) {
+              x[c] = {
+                ...value,
+                v: x[c].v,
+                m: x[c].m,
+              };
+            } else {
+              x[c] = value;
+            }
           }
         }
         flowdata[h] = x;


### PR DESCRIPTION
解决：当空的单元格的格式刷去刷有值的格式刷的时候，有值的格式刷的值会消失。