### PR TITLE
fix:Renaming a non-current sheet also changes the name of the current…

### DIFF
--- a/packages/react/src/components/SheetTab/SheetItem.tsx
+++ b/packages/react/src/components/SheetTab/SheetItem.tsx
@@ -176,6 +176,8 @@ const SheetItem: React.FC<Props> = ({ sheet, isDropPlaceholder }) => {
         const rect = refs.workbookContainer.current!.getBoundingClientRect();
         const { pageX, pageY } = e;
         setContext((ctx) => {
+          //右击的时候先进行跳转
+          ctx.currentSheetId = sheet.id!
           ctx.sheetTabContextMenu = {
             x: pageX - rect.left,
             y: pageY - rect.top,
@@ -189,6 +191,7 @@ const SheetItem: React.FC<Props> = ({ sheet, isDropPlaceholder }) => {
       <span
         className="luckysheet-sheets-item-name"
         spellCheck="false"
+        suppressContentEditableWarning
         contentEditable={isDropPlaceholder ? false : editing}
         onDoubleClick={() => setEditing(true)}
         onBlur={onBlur}


### PR DESCRIPTION
1.BUG：焦点在当前sheet的时候，直接对其他sheet右击改名，则两个sheet名字都会被改掉。
2.解决：参照Luck-sheet，右击的时候先进行sheet跳转。
2.BUG：重命名有的时候会报错。
3.解决：添加一个属性：suppressContentEditableWarning。
