### PR TITLE
fix: Optimize the read-only table function

### DIFF
--- a/packages/core/src/modules/sheet.ts
+++ b/packages/core/src/modules/sheet.ts
@@ -167,7 +167,10 @@ export function deleteSheet(ctx: Context, id: string) {
 }
 
 export function editSheetName(ctx: Context, editable: HTMLSpanElement) {
+  const index = getSheetIndex(ctx, ctx.currentSheetId);
   if (ctx.allowEdit === false) {
+    if (index == null) return;
+    editable.innerText = ctx.luckysheetfile[index].name;
     return;
   }
   const { sheetconfig } = locale(ctx);
@@ -195,7 +198,7 @@ export function editSheetName(ctx: Context, editable: HTMLSpanElement) {
     throw new Error(sheetconfig.sheetNameSpecCharError);
   }
 
-  const index = getSheetIndex(ctx, ctx.currentSheetId);
+  // const index = getSheetIndex(ctx, ctx.currentSheetId);
   if (index == null) return;
 
   for (let i = 0; i < ctx.luckysheetfile.length; i += 1) {

--- a/packages/react/src/components/ContextMenu/SheetTab.tsx
+++ b/packages/react/src/components/ContextMenu/SheetTab.tsx
@@ -39,7 +39,7 @@ const SheetTabContextMenu: React.FC = () => {
 
   const moveSheet = useCallback(
     (delta: number) => {
-      if (!sheet) return;
+      if (!sheet || context.allowEdit === false) return;
       setContext((ctx) => {
         let currentOrder = -1;
         _.sortBy(ctx.luckysheetfile, ["order"]).forEach((_sheet, i) => {
@@ -51,7 +51,7 @@ const SheetTabContextMenu: React.FC = () => {
         api.setSheetOrder(ctx, { [sheet.id!]: currentOrder + delta });
       });
     },
-    [setContext, sheet]
+    [context.allowEdit, setContext, sheet]
   );
 
   if (!sheet || x == null || y == null) return null;


### PR DESCRIPTION
问题：
1.    在只读模式下，可以进行重命名、移动、拖拽sheet。
解决：
1.  重命名问题是因为没有进行ui限制。
2. 移动和拖拽则进行相关的allowEdit参数判断限制。