### PR TITLE
feature: add updateSheet Api

### DIFF
--- a/packages/core/src/api/workbook.ts
+++ b/packages/core/src/api/workbook.ts
@@ -1,8 +1,9 @@
 import _ from "lodash";
-import { Context } from "..";
+import { Context, Sheet } from "..";
 import {
   addSheet as addSheetInternal,
   deleteSheet as deleteSheetInternal,
+  updateSheet as updateSheetInternal,
 } from "../modules";
 import { Settings } from "../settings";
 import { CommonOptions, getSheet } from "./common";
@@ -15,6 +16,10 @@ export function addSheet(ctx: Context, settings: Required<Settings>) {
 export function deleteSheet(ctx: Context, options: CommonOptions = {}) {
   const sheet = getSheet(ctx, options);
   deleteSheetInternal(ctx, sheet.id!);
+}
+
+export function updateSheet(ctx: Context, data: Sheet[]) {
+  updateSheetInternal(ctx, data);
 }
 
 export function activateSheet(ctx: Context, options: CommonOptions = {}) {

--- a/packages/core/src/modules/sheet.ts
+++ b/packages/core/src/modules/sheet.ts
@@ -1,4 +1,5 @@
 import _ from "lodash";
+import { initSheetData } from "../api/sheet";
 import { Context } from "../context";
 import { locale } from "../locale";
 import { Settings } from "../settings";
@@ -187,6 +188,33 @@ export function deleteSheet(ctx: Context, id: string) {
       ctx.hooks.afterDeleteSheet?.(id);
     });
   }
+}
+
+export function updateSheet(ctx: Context, newData: Sheet[]) {
+  newData.forEach((newDatum) => {
+    const { data } = newDatum;
+    const index = getSheetIndex(ctx, newDatum.id!) as number;
+    if (data != null) {
+      const lastRowNum = Math.max(data[0].length, ctx.defaultrowNum);
+      const lastColNum = Math.max(data.length, ctx.defaultcolumnNum);
+      const expandedData: Sheet["data"] = _.times(lastRowNum + 1, () =>
+        _.times(lastColNum + 1, () => null)
+      );
+      for (let i = 0; i < data.length; i += 1) {
+        for (let j = 0; j < data[i].length; j += 1) {
+          expandedData[i][j] = data[i][j];
+        }
+      }
+      newDatum.data = expandedData;
+      if (ctx.luckysheetfile[index] == null) {
+        ctx.luckysheetfile.push(newDatum);
+      } else {
+        ctx.luckysheetfile[index] = newDatum;
+      }
+    } else if (newDatum.celldata != null) {
+      initSheetData(ctx, index, newDatum.celldata);
+    }
+  });
 }
 
 export function editSheetName(ctx: Context, editable: HTMLSpanElement) {

--- a/packages/react/src/components/Workbook/api.ts
+++ b/packages/react/src/components/Workbook/api.ts
@@ -18,6 +18,7 @@ import {
   GlobalCache,
   inverseRowColOptions,
   PatchOptions,
+  Sheet,
 } from "@fortune-sheet/core";
 import produce, { applyPatches, Patch } from "immer";
 import _ from "lodash";
@@ -240,6 +241,9 @@ export function generateAPIs(
 
     deleteSheet: (options: api.CommonOptions = {}) =>
       setContext((draftCtx) => api.deleteSheet(draftCtx, options)),
+
+    updateSheet: (data: Sheet[]) =>
+      setContext((draftCtx) => api.updateSheet(draftCtx, data)),
 
     activateSheet: (options: api.CommonOptions = {}) =>
       setContext((draftCtx) => api.activateSheet(draftCtx, options)),

--- a/stories/API.stories.tsx
+++ b/stories/API.stories.tsx
@@ -519,6 +519,49 @@ export const DeleteSheet: ComponentStory<typeof Workbook> = () => {
   );
 };
 
+export const UpdateSheet: ComponentStory<typeof Workbook> = () => {
+  const ref = useRef<WorkbookInstance>(null);
+  const [data, setData] = useState<Sheet[]>([
+    { id: "1", name: "sheet1", data: [[{ v: "1" }]], order: 0 },
+  ]);
+  const onChange = useCallback((d: Sheet[]) => {
+    setData(d);
+  }, []);
+  return (
+    <ApiExecContainer
+      onRun={() => {
+        // 使用cellData模式更新样例
+        // ref.current?.updateSheet([
+        //   {
+        //     id: "1",
+        //     name: "sheet1",
+        //     celldata: [
+        //       {
+        //         r: 0,
+        //         c: 0,
+        //         v: { ct: { fa: "General", t: "n" }, m: "1", v: "1" },
+        //       },
+        //     ],
+        //     order: 0,
+        //   },
+        // ]);
+        // 使用data更新样例
+        ref.current?.updateSheet([
+          { id: "1", name: "lvjing", data: [[{ v: "1" }]], order: 0 },
+          {
+            id: "2",
+            name: "lvjing2",
+            data: [[{ v: "12" }, { v: "lvjing" }]],
+            order: 1,
+          },
+        ]);
+      }}
+    >
+      <Workbook ref={ref} data={data} onChange={onChange} />
+    </ApiExecContainer>
+  );
+};
+
 export const ActivateSheet: ComponentStory<typeof Workbook> = () => {
   const ref = useRef<WorkbookInstance>(null);
   const [data, setData] = useState<Sheet[]>([


### PR DESCRIPTION
1. 新增更新sheet的api，这样用户就可以再使用组件的时候多次赋值data。
2. 在新增的updateSheet Api中会优先根据sheet里面的data进行更新值，如果data属性不存在，才会根据cellData进行跟新数据。
3. fix #100 