### PR TITLE
fix: formula select

### DIFF
--- a/packages/core/src/events/mouse.ts
+++ b/packages/core/src/events/mouse.ts
@@ -533,8 +533,14 @@ export function handleCellAreaMouseDown(
         };
       }
 
-      rangeSetValue(ctx, cellInput, { row: rowseleted, column: columnseleted });
-
+      if (document.activeElement?.className === "fortune-fx-input") {
+        rangeSetValue(ctx, fxInput, { row: rowseleted, column: columnseleted });
+      } else {
+        rangeSetValue(ctx, cellInput, {
+          row: rowseleted,
+          column: columnseleted,
+        });
+      }
       ctx.formulaCache.rangestart = true;
       ctx.formulaCache.rangedrag_column_start = false;
       ctx.formulaCache.rangedrag_row_start = false;

--- a/packages/core/src/modules/formula.ts
+++ b/packages/core/src/modules/formula.ts
@@ -3079,13 +3079,13 @@ export function rangeSetValue(
       ctx.formulaCache.rangetosheet
     );
   }
-
   // let $editor;
 
   if (
-    ctx.formulaCache.rangestart ||
-    ctx.formulaCache.rangedrag_column_start ||
-    ctx.formulaCache.rangedrag_row_start
+    !israngeseleciton(ctx) &&
+    (ctx.formulaCache.rangestart ||
+      ctx.formulaCache.rangedrag_column_start ||
+      ctx.formulaCache.rangedrag_row_start)
   ) {
     //   if (
     //     $("#luckysheet-search-formula-parm").is(":visible") ||


### PR DESCRIPTION
1. 修复在上方公式栏里编辑公式时，选取下方格子，崩溃的问题
2. 修复sum(a1,a2...)诸如此类用逗号分隔时，第二个及以后的格子，选取错误的问题