### PR TITLE
fix: The devicePixelRatio of workbook is invalid

### DIFF
--- a/packages/react/src/components/Workbook/index.tsx
+++ b/packages/react/src/components/Workbook/index.tsx
@@ -382,6 +382,7 @@ const Workbook = React.forwardRef<WorkbookInstance, Settings & AdditionalProps>(
               initSheetData(draftCtx, cellData!, index);
             });
           }
+          draftCtx.devicePixelRatio = mergedSettings.devicePixelRatio;
           draftCtx.lang = mergedSettings.lang;
           draftCtx.allowEdit = mergedSettings.allowEdit;
           draftCtx.hooks = mergedSettings.hooks;
@@ -492,6 +493,7 @@ const Workbook = React.forwardRef<WorkbookInstance, Settings & AdditionalProps>(
       mergedSettings.column,
       mergedSettings.row,
       mergedSettings.defaultFontSize,
+      mergedSettings.devicePixelRatio,
       mergedSettings.lang,
       mergedSettings.allowEdit,
       mergedSettings.hooks,


### PR DESCRIPTION
1. 使用workbook进行修改devicePixelRatio属性时无效。
2. fix #167 