### PR TITLE
feat: Initializing and updating sheets supports row and column parame…

### DIFF
--- a/packages/core/src/api/sheet.ts
+++ b/packages/core/src/api/sheet.ts
@@ -12,20 +12,33 @@ export { getSheet };
 export function initSheetData(
   draftCtx: Context,
   index: number,
-  cellData?: CellWithRowAndCol[]
+  newData: Sheet
 ): CellMatrix | null {
-  const lastRow = _.maxBy<CellWithRowAndCol>(cellData, "r");
-  const lastCol = _.maxBy(cellData, "c");
-  const lastRowNum = Math.max(lastRow?.r ?? 0, draftCtx.defaultrowNum);
-  const lastColNum = Math.max(lastCol?.c ?? 0, draftCtx.defaultcolumnNum);
+  const { celldata, row, column } = newData;
+  const lastRow = _.maxBy<CellWithRowAndCol>(celldata, "r");
+  const lastCol = _.maxBy(celldata, "c");
+  let lastRowNum = (lastRow?.r ?? 0) + 1;
+  let lastColNum = (lastCol?.c ?? 0) + 1;
+  if (row != null && column != null && row > 0 && column > 0) {
+    lastRowNum = Math.max(lastRowNum, row);
+    lastColNum = Math.max(lastColNum, column);
+  } else {
+    lastRowNum = Math.max(lastRowNum, draftCtx.defaultrowNum);
+    lastColNum = Math.max(lastColNum, draftCtx.defaultcolumnNum);
+  }
   if (lastRowNum && lastColNum) {
-    const expandedData: Sheet["data"] = _.times(lastRowNum + 1, () =>
-      _.times(lastColNum + 1, () => null)
+    const expandedData: Sheet["data"] = _.times(lastRowNum, () =>
+      _.times(lastColNum, () => null)
     );
-    cellData?.forEach((d) => {
+    celldata?.forEach((d) => {
       expandedData[d.r][d.c] = d.v;
     });
-    draftCtx.luckysheetfile[index].data = expandedData;
+    if (draftCtx.luckysheetfile[index] == null) {
+      newData.data = expandedData;
+      draftCtx.luckysheetfile.push(newData);
+    } else {
+      draftCtx.luckysheetfile[index].data = expandedData;
+    }
     return expandedData;
   }
   return null;

--- a/packages/core/src/modules/sheet.ts
+++ b/packages/core/src/modules/sheet.ts
@@ -192,13 +192,21 @@ export function deleteSheet(ctx: Context, id: string) {
 
 export function updateSheet(ctx: Context, newData: Sheet[]) {
   newData.forEach((newDatum) => {
-    const { data } = newDatum;
+    const { data, row, column } = newDatum;
     const index = getSheetIndex(ctx, newDatum.id!) as number;
     if (data != null) {
-      const lastRowNum = Math.max(data[0].length, ctx.defaultrowNum);
-      const lastColNum = Math.max(data.length, ctx.defaultcolumnNum);
-      const expandedData: Sheet["data"] = _.times(lastRowNum + 1, () =>
-        _.times(lastColNum + 1, () => null)
+      // 如果row和column存在的话则进行row和column和data进行比较，如果row和column不存在的话则进行data和default进行比较。
+      let lastRowNum = data[0].length;
+      let lastColNum = data.length;
+      if (row != null && column != null && row > 0 && column > 0) {
+        lastRowNum = Math.max(lastRowNum, row);
+        lastColNum = Math.max(lastColNum, column);
+      } else {
+        lastRowNum = Math.max(lastRowNum, ctx.defaultrowNum);
+        lastColNum = Math.max(lastColNum, ctx.defaultcolumnNum);
+      }
+      const expandedData: Sheet["data"] = _.times(lastRowNum, () =>
+        _.times(lastColNum, () => null)
       );
       for (let i = 0; i < data.length; i += 1) {
         for (let j = 0; j < data[i].length; j += 1) {
@@ -212,7 +220,7 @@ export function updateSheet(ctx: Context, newData: Sheet[]) {
         ctx.luckysheetfile[index] = newDatum;
       }
     } else if (newDatum.celldata != null) {
-      initSheetData(ctx, index, newDatum.celldata);
+      initSheetData(ctx, index, newDatum);
     }
   });
 }

--- a/packages/react/src/components/Workbook/api.ts
+++ b/packages/react/src/components/Workbook/api.ts
@@ -80,7 +80,7 @@ export function generateAPIs(
                 ctx_,
                 specialOp.value.id
               ) as number;
-              api.initSheetData(ctx_, fileIndex, specialOp.value?.celldata);
+              api.initSheetData(ctx_, fileIndex, specialOp.value);
             } else if (specialOp.op === "deleteSheet") {
               deleteSheet(ctx_, specialOp.value.id);
               patches.length = 0;

--- a/packages/react/src/components/Workbook/index.tsx
+++ b/packages/react/src/components/Workbook/index.tsx
@@ -79,24 +79,26 @@ const Workbook = React.forwardRef<WorkbookInstance, Settings & AdditionalProps>(
     const initSheetData = useCallback(
       (
         draftCtx: Context,
-        cellData: CellWithRowAndCol[],
+        newData: SheetType,
         index: number
       ): CellMatrix | null => {
-        const lastRow = _.maxBy<CellWithRowAndCol>(cellData, "r");
-        const lastCol = _.maxBy(cellData, "c");
-        const lastRowNum = Math.max(
-          (lastRow?.r ?? 0) + 1,
-          draftCtx.defaultrowNum
-        );
-        const lastColNum = Math.max(
-          (lastCol?.c ?? 0) + 1,
-          draftCtx.defaultcolumnNum
-        );
+        const { celldata, row, column } = newData;
+        const lastRow = _.maxBy<CellWithRowAndCol>(celldata, "r");
+        const lastCol = _.maxBy(celldata, "c");
+        let lastRowNum = (lastRow?.r ?? 0) + 1;
+        let lastColNum = (lastCol?.c ?? 0) + 1;
+        if (row != null && column != null && row > 0 && column > 0) {
+          lastRowNum = Math.max(lastRowNum, row);
+          lastColNum = Math.max(lastColNum, column);
+        } else {
+          lastRowNum = Math.max(lastRowNum, draftCtx.defaultrowNum);
+          lastColNum = Math.max(lastColNum, draftCtx.defaultcolumnNum);
+        }
         if (lastRowNum && lastColNum) {
           const expandedData: SheetType["data"] = _.times(lastRowNum, () =>
             _.times(lastColNum, () => null)
           );
-          cellData?.forEach((d) => {
+          celldata?.forEach((d) => {
             // TODO setCellValue(draftCtx, d.r, d.c, expandedData, d.v);
             expandedData[d.r][d.c] = d.v;
           });
@@ -378,8 +380,7 @@ const Workbook = React.forwardRef<WorkbookInstance, Settings & AdditionalProps>(
             newData.forEach((newDatum) => {
               const index = getSheetIndex(draftCtx, newDatum.id!) as number;
               const sheet = draftCtx.luckysheetfile?.[index];
-              const cellData = sheet.celldata;
-              initSheetData(draftCtx, cellData!, index);
+              initSheetData(draftCtx, sheet, index);
             });
           }
           draftCtx.lang = mergedSettings.lang;
@@ -401,11 +402,10 @@ const Workbook = React.forwardRef<WorkbookInstance, Settings & AdditionalProps>(
           const sheet = draftCtx.luckysheetfile?.[sheetIdx];
           if (!sheet) return;
 
-          const cellData = sheet.celldata;
           let { data } = sheet;
           // expand cell data
           if (_.isEmpty(data)) {
-            const temp = initSheetData(draftCtx, cellData!, sheetIdx);
+            const temp = initSheetData(draftCtx, sheet, sheetIdx);
             if (!_.isNull(temp)) {
               data = temp;
             }

--- a/stories/API.stories.tsx
+++ b/stories/API.stories.tsx
@@ -530,29 +530,100 @@ export const UpdateSheet: ComponentStory<typeof Workbook> = () => {
   return (
     <ApiExecContainer
       onRun={() => {
-        // 使用cellData模式更新样例
-        // ref.current?.updateSheet([
-        //   {
-        //     id: "1",
-        //     name: "sheet1",
-        //     celldata: [
-        //       {
-        //         r: 0,
-        //         c: 0,
-        //         v: { ct: { fa: "General", t: "n" }, m: "1", v: "1" },
-        //       },
-        //     ],
-        //     order: 0,
-        //   },
-        // ]);
-        // 使用data更新样例
+        // 更新样例
         ref.current?.updateSheet([
-          { id: "1", name: "lvjing", data: [[{ v: "1" }]], order: 0 },
+          {
+            id: "1",
+            name: "lvjing",
+            data: [[{ v: "1" }]],
+            order: 0,
+            row: 10,
+            column: 20,
+            luckysheet_select_save: [
+              {
+                row: [2, 4],
+                column: [4, 6],
+                column_focus: 6,
+                height: 19,
+                height_move: 59,
+                left: 444,
+                left_move: 296,
+                row_focus: 4,
+                top: 80,
+                top_move: 40,
+                width: 73,
+                width_move: 221,
+              },
+            ],
+          },
           {
             id: "2",
             name: "lvjing2",
             data: [[{ v: "12" }, { v: "lvjing" }]],
             order: 1,
+          },
+          {
+            id: "3",
+            name: "lvjing3",
+            celldata: [
+              {
+                r: 0,
+                c: 0,
+                v: {
+                  v: "1",
+                  ct: {
+                    fa: "General",
+                    t: "n",
+                  },
+                  m: "1",
+                },
+              },
+              {
+                r: 1,
+                c: 0,
+                v: {
+                  mc: {
+                    r: 1,
+                    c: 0,
+                    rs: 2,
+                    cs: 2,
+                  },
+                },
+              },
+              {
+                r: 1,
+                c: 1,
+                v: {
+                  mc: {
+                    r: 1,
+                    c: 0,
+                  },
+                },
+              },
+              {
+                r: 2,
+                c: 0,
+                v: {
+                  mc: {
+                    r: 1,
+                    c: 0,
+                  },
+                },
+              },
+              {
+                r: 2,
+                c: 1,
+                v: {
+                  mc: {
+                    r: 1,
+                    c: 0,
+                  },
+                },
+              },
+            ],
+            row: 20,
+            column: 20,
+            order: 3,
           },
         ]);
       }}


### PR DESCRIPTION
1. 初始化sheet的时候和更新sheet的api时候支持参数row和column对sheet进行构建。
2. 会优先进行row和column的参数判断，如果row和column参数存在则会判断data大还是row和column大。如果row和column不存在，则会判断是data大还是默认的row和column大，最后以大的长度来构建sheet。
3. 示例：
![image](https://user-images.githubusercontent.com/47999156/210492911-a11b2962-3e7f-4970-ac2c-af27e65afce4.png)
4. fix #119 
5. fix #158 
