### PR TITLE
feat: New hide/show column function

### DIFF
--- a/packages/core/src/events/keyboard.ts
+++ b/packages/core/src/events/keyboard.ts
@@ -1,5 +1,5 @@
 import _ from "lodash";
-import { removeActiveImage } from "..";
+import { hideCRCount, removeActiveImage } from "..";
 import { Context, getFlowdata } from "../context";
 import { updateCell, cancelNormalSelected } from "../modules/cell";
 import { handleFormulaInput } from "../modules/formula";
@@ -407,18 +407,19 @@ export function handleArrowKey(ctx: Context, e: KeyboardEvent) {
     return;
   }
 
+  const moveCount = hideCRCount(ctx, e.key);
   switch (e.key) {
     case "ArrowUp":
-      moveHighlightCell(ctx, "down", -1, "rangeOfSelect");
+      moveHighlightCell(ctx, "down", -moveCount, "rangeOfSelect");
       break;
     case "ArrowDown":
-      moveHighlightCell(ctx, "down", 1, "rangeOfSelect");
+      moveHighlightCell(ctx, "down", moveCount, "rangeOfSelect");
       break;
     case "ArrowLeft":
-      moveHighlightCell(ctx, "right", -1, "rangeOfSelect");
+      moveHighlightCell(ctx, "right", -moveCount, "rangeOfSelect");
       break;
     case "ArrowRight":
-      moveHighlightCell(ctx, "right", 1, "rangeOfSelect");
+      moveHighlightCell(ctx, "right", moveCount, "rangeOfSelect");
       break;
     default:
       break;

--- a/packages/core/src/modules/cell.ts
+++ b/packages/core/src/modules/cell.ts
@@ -1544,7 +1544,6 @@ export function getdatabyselection(
   }
 
   const data = [];
-
   for (let r = range.row[0]; r <= range.row[1]; r += 1) {
     if (d?.[r] == null) {
       continue;
@@ -1556,12 +1555,14 @@ export function getdatabyselection(
     const row = [];
 
     for (let c = range.column[0]; c <= range.column[1]; c += 1) {
+      if (cfg?.colhidden != null && cfg.colhidden[c] != null) {
+        continue;
+      }
       row.push(d[r][c]);
     }
 
     data.push(row);
   }
-
   return data;
 }
 

--- a/packages/core/src/modules/selection.ts
+++ b/packages/core/src/modules/selection.ts
@@ -119,14 +119,18 @@ export function normalizeSelection(
     selection[i].column_focus = cf;
 
     selection[i].left = col_pre_f;
-    selection[i].width = col_f - col_pre_f - 1;
+    // selection[i].width = col_f - col_pre_f - 1;
+    selection[i].width = col_f - col_pre_f <= 0 ? 0 : col_f - col_pre_f - 1;
     selection[i].top = row_pre_f;
-    selection[i].height = row_f - row_pre_f - 1;
+    // selection[i].height = row_f - row_pre_f - 1;
+    selection[i].height = row_f - row_pre_f <= 0 ? 0 : row_f - row_pre_f - 1;
 
     selection[i].left_move = col_pre;
-    selection[i].width_move = col - col_pre - 1;
+    // selection[i].width_move = col - col_pre - 1;
+    selection[i].width_move = col - col_pre <= 0 ? 0 : col - col_pre - 1;
     selection[i].top_move = row_pre;
-    selection[i].height_move = row - row_pre - 1;
+    // selection[i].height_move = row - row_pre - 1;
+    selection[i].height_move = row - row_pre <= 0 ? 0 : row - row_pre - 1;
   }
   return selection;
 }

--- a/packages/core/src/settings.ts
+++ b/packages/core/src/settings.ts
@@ -213,9 +213,9 @@ export const defaultSettings: Required<Settings> = {
     "delete-row", // 删除选中行
     "delete-column", // 删除选中列
     "delete-cell", // 删除单元格
-    "|",
     "hide-row", // 隐藏选中行和显示选中行
     "hide-column", // 隐藏选中列和显示选中列
+    "|",
     "clear", // 清除内容
     "sort", // 排序选区
     "orderAZ", // 升序

--- a/packages/react/src/components/ContextMenu/index.tsx
+++ b/packages/react/src/components/ContextMenu/index.tsx
@@ -10,21 +10,25 @@ import {
   createFilter,
   showImgChooser,
   handleLink,
+  hideSelected,
+  showSelected,
 } from "@fortune-sheet/core";
 import _ from "lodash";
 import React, { useContext, useRef, useLayoutEffect, useCallback } from "react";
 import WorkbookContext, { SetContextOptions } from "../../context";
 import { useAlert } from "../../hooks/useAlert";
+import { useDialog } from "../../hooks/useDialog";
 import Divider from "./Divider";
 import "./index.css";
 import Menu from "./Menu";
 
 const ContextMenu: React.FC = () => {
+  const { showDialog } = useDialog();
   const containerRef = useRef<HTMLDivElement>(null);
   const { context, setContext, settings } = useContext(WorkbookContext);
   const { contextMenu } = context;
   const { showAlert } = useAlert();
-  const { rightclick } = locale(context);
+  const { rightclick, drag } = locale(context);
   const getMenuElement = useCallback(
     (name: string, i: number) => {
       const selection = context.luckysheet_select_save?.[0];
@@ -249,6 +253,58 @@ const ContextMenu: React.FC = () => {
           </Menu>
         );
       }
+      if (name === "hide-row") {
+        return (
+          selection?.row_select === true &&
+          ["hideSelected", "showHide"].map((item) => (
+            <Menu
+              key={item}
+              onClick={() => {
+                setContext((draftCtx) => {
+                  let msg = "";
+                  if (item === "hideSelected") {
+                    msg = hideSelected(draftCtx, "row");
+                  } else if (item === "showHide") {
+                    showSelected(draftCtx, "row");
+                  }
+                  if (msg === "noMulti") {
+                    showDialog(drag.noMulti);
+                  }
+                  draftCtx.contextMenu = undefined;
+                });
+              }}
+            >
+              {(rightclick as any)[item] + rightclick.row}
+            </Menu>
+          ))
+        );
+      }
+      if (name === "hide-column") {
+        return (
+          selection?.column_select === true &&
+          ["hideSelected", "showHide"].map((item) => (
+            <Menu
+              key={item}
+              onClick={() => {
+                setContext((draftCtx) => {
+                  let msg = "";
+                  if (item === "hideSelected") {
+                    msg = hideSelected(draftCtx, "column");
+                  } else if (item === "showHide") {
+                    showSelected(draftCtx, "column");
+                  }
+                  if (msg === "noMulti") {
+                    showDialog(drag.noMulti);
+                  }
+                  draftCtx.contextMenu = undefined;
+                });
+              }}
+            >
+              {(rightclick as any)[item] + rightclick.column}
+            </Menu>
+          ))
+        );
+      }
       if (name === "clear") {
         return (
           <Menu
@@ -368,6 +424,8 @@ const ContextMenu: React.FC = () => {
       rightclick,
       setContext,
       showAlert,
+      showDialog,
+      drag,
     ]
   );
 

--- a/packages/react/src/components/FxEditor/index.tsx
+++ b/packages/react/src/components/FxEditor/index.tsx
@@ -10,6 +10,7 @@ import {
   handleFormulaInput,
   rangeHightlightselected,
   valueShowEs,
+  isShowHidenCR,
 } from "@fortune-sheet/core";
 import React, {
   useContext,
@@ -33,11 +34,14 @@ const FxEditor: React.FC = () => {
   const [focused, setFocused] = useState(false);
   const lastKeyDownEventRef = useRef<KeyboardEvent>();
   const inputContainerRef = useRef<HTMLDivElement>(null);
+  const [isHidenRC, setIsHidenRC] = useState<boolean>(false);
   const firstSelection = context.luckysheet_select_save?.[0];
   const prevFirstSelection = usePrevious(firstSelection);
   const prevSheetId = usePrevious(context.currentSheetId);
 
   useEffect(() => {
+    // 当选中行列是处于隐藏状态的话则不允许编辑
+    setIsHidenRC(isShowHidenCR(context));
     if (
       _.isEqual(prevFirstSelection, firstSelection) &&
       context.currentSheetId === prevSheetId
@@ -276,7 +280,9 @@ const FxEditor: React.FC = () => {
           onChange={onChange}
           onBlur={() => setFocused(false)}
           tabIndex={0}
-          allowEdit={context.allowEdit}
+          allowEdit={
+            context.allowEdit === true ? !isHidenRC : context.allowEdit
+          }
         />
         {focused && (
           <>

--- a/packages/react/src/components/SheetOverlay/InputBox.tsx
+++ b/packages/react/src/components/SheetOverlay/InputBox.tsx
@@ -12,6 +12,7 @@ import {
   valueShowEs,
   updateCell,
   createRangeHightlight,
+  isShowHidenCR,
 } from "@fortune-sheet/core";
 import React, {
   useContext,
@@ -20,6 +21,7 @@ import React, {
   useRef,
   useCallback,
   useLayoutEffect,
+  useState,
 } from "react";
 import _ from "lodash";
 import WorkbookContext from "../../context";
@@ -34,6 +36,7 @@ const InputBox: React.FC = () => {
   const lastKeyDownEventRef = useRef<KeyboardEvent>();
   const prevCellUpdate = usePrevious<any[]>(context.luckysheetCellUpdate);
   const prevSheetId = usePrevious<string>(context.currentSheetId);
+  const [isHidenRC, setIsHidenRC] = useState<boolean>(false);
   const firstSelection = context.luckysheet_select_save?.[0];
   const row_index = firstSelection?.row_focus!;
   const col_index = firstSelection?.column_focus!;
@@ -112,6 +115,12 @@ const InputBox: React.FC = () => {
       }
     }
   }, [context.luckysheetCellUpdate]);
+
+  // 当选中行列是处于隐藏状态的话则不允许编辑
+  useEffect(() => {
+    setIsHidenRC(isShowHidenCR(context));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [context.luckysheet_select_save]);
 
   const onKeyDown = useCallback(
     (e: React.KeyboardEvent<HTMLDivElement>) => {
@@ -318,7 +327,7 @@ const InputBox: React.FC = () => {
           onChange={onChange}
           onKeyDown={onKeyDown}
           onPaste={onPaste}
-          allowEdit={edit}
+          allowEdit={edit ? !isHidenRC : edit}
         />
       </div>
       {document.activeElement === inputRef.current && (


### PR DESCRIPTION
1. 新增隐藏和显示行列功能。
2. 改进Luckysheet处：
    一、被隐藏的行列单元格和公式栏不允许编辑。
    二、当前选区被隐藏的时候，选区会自动跳到下一行/下一列。
    三、键盘移动到隐藏行列的时候会直接跳过。
    四、键盘或者右击功能复制粘贴会去除隐藏部分。
3. 修复一些选区处理和单元格处理的bug。
4. fix: #154 