### PR TITLE
fix: addSheet setContext called twice

### DIFF
--- a/packages/react/src/components/SheetTab/index.tsx
+++ b/packages/react/src/components/SheetTab/index.tsx
@@ -83,20 +83,22 @@ const SheetTab: React.FC = () => {
           <div
             className="fortune-sheettab-button"
             onClick={() => {
-              setContext(
-                (draftCtx) => {
-                  if (draftCtx.luckysheetCellUpdate.length > 0) {
-                    updateCell(
-                      draftCtx,
-                      draftCtx.luckysheetCellUpdate[0],
-                      draftCtx.luckysheetCellUpdate[1],
-                      refs.cellInput.current!
-                    );
-                  }
-                  addSheet(draftCtx, settings);
-                },
-                { addSheetOp: true }
-              );
+              _.debounce(() => {
+                setContext(
+                  (draftCtx) => {
+                    if (draftCtx.luckysheetCellUpdate.length > 0) {
+                      updateCell(
+                        draftCtx,
+                        draftCtx.luckysheetCellUpdate[0],
+                        draftCtx.luckysheetCellUpdate[1],
+                        refs.cellInput.current!
+                      );
+                    }
+                    addSheet(draftCtx, settings);
+                  },
+                  { addSheetOp: true }
+                );
+              }, 300)();
               const tabCurrent = tabContainerRef.current;
               setIsShowScrollBtn(
                 tabCurrent!.scrollWidth > tabCurrent!.clientWidth


### PR DESCRIPTION
fix: addSheet setContext called twice when clicking the add sheet button quickly