### PR TITLE
fix: destory sheetTabContextMenu when click sheetList

### DIFF
--- a/packages/react/src/components/SheetTab/index.tsx
+++ b/packages/react/src/components/SheetTab/index.tsx
@@ -118,6 +118,7 @@ const SheetTab: React.FC = () => {
                   ctx.showSheetList = _.isUndefined(ctx.showSheetList)
                     ? true
                     : !ctx.showSheetList;
+                  ctx.sheetTabContextMenu = {};
                 });
               }}
             >


### PR DESCRIPTION
fix: destory sheetTabContextMenu when click sheetList button