### PR TITLE
fix: WorkbookInstance export warning

### DIFF
--- a/packages/react/src/components/index.ts
+++ b/packages/react/src/components/index.ts
@@ -1,3 +1,4 @@
-import Workbook, { WorkbookInstance } from "./Workbook";
+import Workbook from "./Workbook";
 
-export { Workbook, WorkbookInstance };
+export { Workbook };
+export type { WorkbookInstance } from "./Workbook";


### PR DESCRIPTION
fix the warning '''./packages/react/src/components/index.ts 2:0-38"export 'WorkbookInstance' was not found in './Workbook''' when render the workbook