### PR TITLE
fix: selection bug

### DIFF
--- a/packages/react/src/components/SheetOverlay/index.tsx
+++ b/packages/react/src/components/SheetOverlay/index.tsx
@@ -265,7 +265,13 @@ const SheetOverlay: React.FC = () => {
   useEffect(() => {
     refs.cellArea.current!.scrollLeft = context.scrollLeft;
     refs.cellArea.current!.scrollTop = context.scrollTop;
-  }, [context.scrollLeft, context.scrollTop, refs.cellArea]);
+  }, [
+    context.scrollLeft,
+    context.scrollTop,
+    refs.cellArea,
+    refs.cellArea.current?.scrollLeft,
+    refs.cellArea.current?.scrollTop,
+  ]);
 
   useEffect(() => {
     // ensure cell input is always focused to accept first key stroke on cell


### PR DESCRIPTION
1. 问题：在最后一列或最后一行鼠标单击cell，然后键盘输入内容有概率输入框会偏移、在任意一个cell中鼠标单击，再移动滚动条，使用键盘移动选区有概率会出现偏移。
2. 解决，只监听refs.cellArea属性有的时候会监听不到，监听属性具体。