### PR TITLE
fix: undefiend numeric parameters

### DIFF
--- a/packages/formula-parser/src/parser.js
+++ b/packages/formula-parser/src/parser.js
@@ -177,6 +177,14 @@ class Parser extends Emitter {
    */
   _callCellValue(label) {
     const [row, column, sheetName] = extractLabel(label);
+    if (row?.index === -1) {
+      throw Error(ERROR_NAME);
+    } else if (column?.index === -1) {
+      if (row.isAbsolute || column.isAbsolute) {
+        throw Error(ERROR_NAME);
+      }
+      return row.index + 1;
+    }
     let value = void 0;
 
     this.emit('callCellValue', {label, row, column, sheetName}, this.options, (_value) => {


### PR DESCRIPTION
* fix #240 
* The regular expression in #229 (enble selecting row and cols) lead to numeric parameter recognized as cellValue. Temporary solution is checking it in _callCellValue.