### PR TITLE
fix: '<' or '>' be escaped in formula

### DIFF
--- a/packages/core/src/modules/format.ts
+++ b/packages/core/src/modules/format.ts
@@ -315,7 +315,11 @@ function fuzzynum(s: string | number) {
 
 export function escapeHTML(preValue: string) {
   let resultValue = preValue;
-  if (!resultValue && typeof resultValue !== "string") return preValue;
+  if (
+    (!resultValue && typeof resultValue !== "string") ||
+    preValue.startsWith("=")
+  )
+    return preValue;
   try {
     resultValue = resultValue.replace(/</g, "&lt;").replace(/>/g, "&gt;");
   } catch {


### PR DESCRIPTION
fix: '<' or '>' be escaped in formula