### PR TITLE
fix: copy and paste in safari

### DIFF
--- a/packages/core/src/modules/clipboard.ts
+++ b/packages/core/src/modules/clipboard.ts
@@ -17,7 +17,6 @@ export default class clipboard {
       ele.focus({ preventScroll: true });
       document.execCommand("selectAll");
       document.execCommand("copy");
-      ele.style.display = "none";
     } catch (e) {
       console.error(e);
     }


### PR DESCRIPTION
fix: copy and paste in safari
fix #325 