### PR TITLE
Rework on fixing undo/redo keyboard shortcut

### DIFF
--- a/packages/core/src/events/keyboard.ts
+++ b/packages/core/src/events/keyboard.ts
@@ -163,7 +163,7 @@ export function handleWithCtrlOrMetaKey(
       handleFormulaInput(ctx, fxInput, cellInput, e.keyCode);
     } else if (e.key === "z") {
       // Ctrl + shift + z 重做
-      setTimeout(handleRedo);
+      handleRedo();
       e.stopPropagation();
       return;
     }
@@ -272,7 +272,7 @@ export function handleWithCtrlOrMetaKey(
     return;
   } else if (e.key === "z") {
     // Ctrl + Z  撤销
-    setTimeout(handleUndo);
+    handleUndo();
     e.stopPropagation();
     return;
   } /* else if (e.key === "ArrowUp") {

--- a/packages/react/src/components/Workbook/index.tsx
+++ b/packages/react/src/components/Workbook/index.tsx
@@ -539,6 +539,18 @@ const Workbook = React.forwardRef<WorkbookInstance, Settings & AdditionalProps>(
     const onKeyDown = useCallback(
       (e: React.KeyboardEvent<HTMLDivElement>) => {
         const { nativeEvent } = e;
+        // handling undo and redo ahead because handleUndo and handleRedo
+        // themselves are calling setContext, and should not be nested
+        // in setContextWithProduce.
+        if ((e.ctrlKey || e.metaKey) && e.key === "z") {
+          if (e.shiftKey) {
+            handleRedo();
+          } else {
+            handleUndo();
+          }
+          e.stopPropagation();
+          return;
+        }
         setContextWithProduce((draftCtx) => {
           handleGlobalKeyDown(
             draftCtx,
@@ -546,7 +558,7 @@ const Workbook = React.forwardRef<WorkbookInstance, Settings & AdditionalProps>(
             fxInput.current!,
             nativeEvent,
             globalCache.current!,
-            handleUndo,
+            handleUndo, // still passing handleUndo and handleRedo here to satisfy API
             handleRedo,
             canvas.current!.getContext("2d")!
           );


### PR DESCRIPTION
Rework for f5bdef4c85b2cdcf3d218e969feced8e02baabd0

The root cause is that `handleUndo` and `handleRedo`, who are calling `setContext`, are called in `setContextWithProduce`. Resulting nested `setContext` calls. This is undefined behavior in React. It works in React <= 18.1.0, but breaks in React 18.2.0

To avoid nested calls. We have to deal with undo/redo separately. We do not need to remove undo/redo logic in `handleGlobalKeyDown` for now as they might be useful for other framework support in the future, such as Vue.