### PR TITLE
Improve "Download and install the library" in README 

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -99,13 +99,30 @@
 ## 快速开始 (react)
 
 ### 安装库
-```shell
-yarn add @fortune-sheet/react
-```
-或使用 npm:
+
+<details open>
+<summary>使用 npm</summary>
+
 ```shell
 npm install @fortune-sheet/react
 ```
+</details>
+
+<details>
+<summary>使用 pnpm</summary>
+
+```shell
+pnpm install @fortune-sheet/react
+```
+</details>
+
+<details>
+<summary>使用 yarn</summary>
+
+```shell
+yarn add @fortune-sheet/react
+```
+</details>
 
 ### 创建一个HTML容器
 ```html

--- a/README.md
+++ b/README.md
@@ -102,13 +102,30 @@ See detailed documentation at [fortune-sheet-doc](https://ruilisi.github.io/fort
 ## Get started (react)
 
 ### Download and install the library
-```shell
-yarn add @fortune-sheet/react
-```
-or using npm:
+
+<details open>
+<summary>Using npm</summary>
+
 ```shell
 npm install @fortune-sheet/react
 ```
+</details>
+
+<details>
+<summary>Using pnpm</summary>
+
+```shell
+pnpm install @fortune-sheet/react
+```
+</details>
+
+<details>
+<summary>Using yarn</summary>
+
+```shell
+yarn add @fortune-sheet/react
+```
+</details>
 
 ### Create an HTML placeholder
 ```html


### PR DESCRIPTION
Added npm as default install and other options as a dropdown. Also included pnpm so users of that package manager need to type less.

Feel free to adjust the Chinese version. I have translated it with deepl.com