### PR TITLE
fix: improve freeze handler

### DIFF
--- a/packages/react/src/components/SheetOverlay/ColumnHeader.tsx
+++ b/packages/react/src/components/SheetOverlay/ColumnHeader.tsx
@@ -43,7 +43,8 @@ const ColumnHeader: React.FC = () => {
     if (
       sheet?.frozen?.type === "column" ||
       sheet?.frozen?.type === "rangeColumn" ||
-      sheet?.frozen?.type === "rangeBoth"
+      sheet?.frozen?.type === "rangeBoth" ||
+      sheet?.frozen?.type === "both"
     ) {
       return (
         colLocationByIndex(

--- a/packages/react/src/components/SheetOverlay/RowHeader.tsx
+++ b/packages/react/src/components/SheetOverlay/RowHeader.tsx
@@ -39,7 +39,8 @@ const RowHeader: React.FC = () => {
     if (
       sheet?.frozen?.type === "row" ||
       sheet?.frozen?.type === "rangeRow" ||
-      sheet?.frozen?.type === "rangeBoth"
+      sheet?.frozen?.type === "rangeBoth" ||
+      sheet?.frozen?.type === "both"
     ) {
       return (
         rowLocationByIndex(

--- a/packages/react/src/components/Toolbar/index.css
+++ b/packages/react/src/components/Toolbar/index.css
@@ -150,7 +150,7 @@
   padding: 6px;
   font-size: 12px;
   position: absolute;
-  z-index: 1;
+  z-index: 25; /* higher than toolbar tips */
   top: 40px;
   white-space: nowrap;
 }


### PR DESCRIPTION
fix:
   * fix: z-index of freeze handler higher than the z-index of toolbar tips
   * fix #370 

improve:
   * freeze handler will be hidden when there is no frozen area