### PR TITLE
fix: cannot use mouse to change cursor in sheetTab in firefox

### DIFF
--- a/packages/react/src/components/SheetTab/SheetItem.tsx
+++ b/packages/react/src/components/SheetTab/SheetItem.tsx
@@ -155,7 +155,7 @@ const SheetItem: React.FC<Props> = ({ sheet, isDropPlaceholder }) => {
       }}
       onDrop={onDrop}
       onDragStart={onDragStart}
-      draggable={context.allowEdit}
+      draggable={context.allowEdit && !editing}
       key={sheet.id}
       ref={containerRef}
       className={


### PR DESCRIPTION
fix: cannot use mouse to change cursor in sheetTab when rename a sheet in firefox