### PR TITLE
fix: make scrollToHighlightCell generic

### DIFF
--- a/packages/core/src/modules/selection.ts
+++ b/packages/core/src/modules/selection.ts
@@ -61,7 +61,7 @@ export function scrollToHighlightCell(ctx: Context, r: number, c: number) {
   if (row - scrollTop - winH + 20 > 0) {
     ctx.scrollTop = row - winH + 20;
   } else if (row_pre - scrollTop - freezeH < 0) {
-    const scrollAmount = Math.max(100, freezeH);
+    const scrollAmount = Math.max(20, freezeH);
     ctx.scrollTop = row_pre - scrollAmount;
   }
 }

--- a/packages/core/src/modules/selection.ts
+++ b/packages/core/src/modules/selection.ts
@@ -33,6 +33,19 @@ export function scrollToHighlightCell(ctx: Context, r: number, c: number) {
   const winH = ctx.cellmainHeight;
   const winW = ctx.cellmainWidth;
 
+  const sheetIndex = getSheetIndex(ctx, ctx.currentSheetId);
+  const sheet = sheetIndex == null ? null : ctx.luckysheetfile[sheetIndex];
+
+  if (!sheet) return;
+
+  const frozen = sheet?.frozen;
+  const row_focus = sheet?.frozen?.range?.row_focus || 0;
+  const column_focus = sheet?.frozen?.range?.column_focus || 0;
+
+  const freezeH = frozen && r > row_focus ? ctx.visibledatarow[row_focus] : 0;
+  const freezeW =
+    frozen && c > column_focus ? ctx.visibledatacolumn[column_focus] : 0;
+
   const row = ctx.visibledatarow[r];
   const row_pre = r - 1 === -1 ? 0 : ctx.visibledatarow[r - 1];
   const col = ctx.visibledatacolumn[c];
@@ -40,14 +53,16 @@ export function scrollToHighlightCell(ctx: Context, r: number, c: number) {
 
   if (col - scrollLeft - winW + 20 > 0) {
     ctx.scrollLeft = col - winW + 20;
-  } else if (col_pre - scrollLeft < 0) {
-    ctx.scrollLeft = col_pre - 20;
+  } else if (col_pre - scrollLeft - freezeW < 0) {
+    const scrollAmount = Math.max(20, freezeW);
+    ctx.scrollLeft = col_pre - scrollAmount;
   }
 
   if (row - scrollTop - winH + 20 > 0) {
     ctx.scrollTop = row - winH + 20;
-  } else if (row_pre - scrollTop < 0) {
-    ctx.scrollTop = row_pre - 20;
+  } else if (row_pre - scrollTop - freezeH < 0) {
+    const scrollAmount = Math.max(100, freezeH);
+    ctx.scrollTop = row_pre - scrollAmount;
   }
 }
 


### PR DESCRIPTION
Resolves #391

This pull request was necessitated due to Issue #391. The existing implementation of `scrollToHighlightCell` has two issues - 

1. It does not handle the cases where some rows or columns are frozen.
2. For scroll up/left, it has hardcoded values of 100 and 20 respectively which are not generic and won't suit the use cases where the cells above exceed these values.

To solve the first point, I am now checking if the sheet is frozen or not. If yes, then we set `freezeH` as the height of the total frozen rows, and `freezeW` as the width of the total frozen columns. In case there is no frozen in the context, we just set both of these to 0. When the scroll up/left conditions are triggered in lines 56 and 63, we simply check if `col_pre - scrollLeft - freezeW < 0` or `row_pre - scrollTop - freezeH < 0` are less than 0. Subtracting freeze allows us to prematurely scroll in case of frozen table, while not impacting non frozen tables at all.

To solve the second point, instead of scrolling by a fixed value of 20 or 100, I am making it scroll by maximum of the previously hardcoded value of 20/100 and the `freezeW`/`freezeH` parameter to make the scroll amount generic.


Edit - both hardcoded values were 20, I mistakenly took one of them as 100.