### PR TITLE
fix: language based stats number format

### DIFF
--- a/packages/core/src/modules/selection.ts
+++ b/packages/core/src/modules/selection.ts
@@ -2341,7 +2341,7 @@ export function fixColumnStyleOverflowInFreeze(
   return ret;
 }
 
-export function calcSelectionInfo(ctx: Context) {
+export function calcSelectionInfo(ctx: Context, lang?: string | null) {
   const selection = ctx.luckysheet_select_save!;
   let numberC = 0;
   let count = 0;
@@ -2369,9 +2369,11 @@ export function calcSelectionInfo(ctx: Context) {
       }
     }
   }
-  const average: string = SSF.format("w0.00", sum / numberC);
-  sum = SSF.format("w0.00", sum);
-  max = SSF.format("w0.00", max);
-  min = SSF.format("w0.00", min);
+  const formatString =
+    lang && !["zh", "zh_tw"].includes(lang) ? "0.00" : "w0.00";
+  const average: string = SSF.format(formatString, sum / numberC);
+  sum = SSF.format(formatString, sum);
+  max = SSF.format(formatString, max);
+  min = SSF.format(formatString, min);
   return { numberC, count, sum, max, min, average };
 }

--- a/packages/react/src/components/Workbook/index.tsx
+++ b/packages/react/src/components/Workbook/index.tsx
@@ -100,8 +100,9 @@ const Workbook = React.forwardRef<WorkbookInstance, Settings & AdditionalProps>(
     // 计算选区的信息
     useEffect(() => {
       const selection = context.luckysheet_select_save;
+      const { lang } = props;
       if (selection) {
-        const re = calcSelectionInfo(context);
+        const re = calcSelectionInfo(context, lang);
         setCalInfo(re);
       }
       // eslint-disable-next-line react-hooks/exhaustive-deps


### PR DESCRIPTION
Resolves #408 

Currently, all languages had Chinese characters in the stat area. I have changed it in this PR such that only Chinese and Chinese Traditional table languages (and by default if no language is specified) then the behaviour remains the same, but if user specified any other lang than these 2 then the number format wont include the Chinese characters.