### PR TITLE
Filter range/icon handling for frozen sheets

### DIFF
--- a/packages/core/src/modules/selection.ts
+++ b/packages/core/src/modules/selection.ts
@@ -51,95 +51,18 @@ export function scrollToHighlightCell(ctx: Context, r: number, c: number) {
   const col = ctx.visibledatacolumn[c];
   const col_pre = c - 1 === -1 ? 0 : ctx.visibledatacolumn[c - 1];
 
-  const colRangeStart = ctx.luckysheet_select_save?.[0].column[0];
-  const colRangeEnd = ctx.luckysheet_select_save?.[0].column[1];
-  const rowRangeStart = ctx.luckysheet_select_save?.[0].row[0];
-  const rowRangeEnd = ctx.luckysheet_select_save?.[0].row[1];
-
-  const selectionColumnFocus = ctx.luckysheet_select_save?.[0].column_focus;
-  const selectionRowFocus = ctx.luckysheet_select_save?.[0].row_focus;
-
-  let scrollAmount = Math.max(20, freezeW);
-
-  // Rightward movement of cell/selection
   if (col - scrollLeft - winW + 20 > 0) {
-    // If selection size is shrinking towards right
-    const isShrinking = colRangeEnd === selectionColumnFocus;
-    // If selection is shrinking, then scroll to keep the rightmost cell in selection visible
-    if (isShrinking && colRangeStart && colRangeStart !== colRangeEnd) {
-      const colRangeStart_pre = Math.max(0, colRangeStart - 1);
-      if (colRangeStart_pre < column_focus) ctx.scrollLeft = 0;
-      else
-        ctx.scrollLeft =
-          ctx.visibledatacolumn[colRangeStart_pre] - scrollAmount;
-    }
-    // Otherwise just scroll by fixed amount
-    else ctx.scrollLeft = ctx.visibledatacolumn[frozen ? c + 1 : c] - winW + 20;
-  }
-  // Leftward movement of cell/selection
-  else if (col_pre - scrollLeft - freezeW < 0) {
-    // If selection size is shrinking towards left
-    const isShrinking = colRangeStart === selectionColumnFocus;
-    // If selection is shrinking, then scroll to keep the leftmost cell in selection visible
-    if (
-      isShrinking &&
-      colRangeEnd &&
-      colRangeStart !== colRangeEnd &&
-      ctx.visibledatacolumn[colRangeEnd] < ctx.scrollLeft + winW
-    ) {
-      ctx.scrollLeft =
-        ctx.visibledatacolumn[frozen ? colRangeEnd + 1 : colRangeEnd] -
-        winW +
-        scrollAmount;
-    }
-    // Otherwise just scroll by fixed amount
-    else ctx.scrollLeft = col_pre - scrollAmount;
+    ctx.scrollLeft = col - winW + 20;
+  } else if (col_pre - scrollLeft - freezeW < 0) {
+    const scrollAmount = Math.max(20, freezeW);
+    ctx.scrollLeft = col_pre - scrollAmount;
   }
 
-  scrollAmount = Math.max(20, freezeH);
-
-  // Downward movement of cell/selection
   if (row - scrollTop - winH + 20 > 0) {
-    const isShrinking = rowRangeEnd === selectionRowFocus;
-    // If selection is shrinking, then scroll to keep the topmost cell in selection visible
-    if (isShrinking && rowRangeStart && rowRangeStart !== rowRangeEnd) {
-      const rowRangeStart_pre = Math.max(0, rowRangeStart - 1);
-      // Don't scroll if topmost cell is within frozen range
-      if (rowRangeStart_pre < row_focus) ctx.scrollTop = 0;
-      else ctx.scrollTop = ctx.visibledatarow[rowRangeStart_pre] - scrollAmount;
-    }
-    // Otherwise just scroll by fixed amount
-    else ctx.scrollTop = row - winH + 20;
-  }
-  // Upward movement of cell/selection
-  else if (row_pre - scrollTop - freezeH < 0) {
-    const isShrinking = rowRangeStart === selectionRowFocus;
-
-    // If selection is shrinking, then scroll to keep the bottom most cell in selection visible
-    if (
-      isShrinking &&
-      rowRangeEnd &&
-      rowRangeStart !== rowRangeEnd &&
-      ctx.visibledatarow[rowRangeEnd] < ctx.scrollTop + winH
-    ) {
-      ctx.scrollTop = ctx.visibledatarow[rowRangeEnd] - winH + scrollAmount;
-    }
-    // Otherwise just scroll by fixed amount
-    else {
-      ctx.scrollTop = row_pre - scrollAmount;
-    }
-  } else if (
-    frozen &&
-    rowRangeEnd &&
-    colRangeEnd &&
-    (rowRangeStart !== rowRangeEnd || colRangeStart !== colRangeEnd)
-  ) {
-    if (ctx.visibledatarow[rowRangeEnd] + 20 < scrollTop + winH) {
-      ctx.scrollTop = Math.max(0, ctx.scrollTop - scrollAmount);
-    }
-    if (ctx.visibledatacolumn[colRangeEnd] + 20 < scrollLeft + winW) {
-      ctx.scrollLeft = Math.max(0, ctx.scrollLeft - scrollAmount);
-    }
+    ctx.scrollTop = row - winH + 20;
+  } else if (row_pre - scrollTop - freezeH < 0) {
+    const scrollAmount = Math.max(20, freezeH);
+    ctx.scrollTop = row_pre - scrollAmount;
   }
 }
 

--- a/packages/core/src/modules/selection.ts
+++ b/packages/core/src/modules/selection.ts
@@ -51,18 +51,95 @@ export function scrollToHighlightCell(ctx: Context, r: number, c: number) {
   const col = ctx.visibledatacolumn[c];
   const col_pre = c - 1 === -1 ? 0 : ctx.visibledatacolumn[c - 1];
 
+  const colRangeStart = ctx.luckysheet_select_save?.[0].column[0];
+  const colRangeEnd = ctx.luckysheet_select_save?.[0].column[1];
+  const rowRangeStart = ctx.luckysheet_select_save?.[0].row[0];
+  const rowRangeEnd = ctx.luckysheet_select_save?.[0].row[1];
+
+  const selectionColumnFocus = ctx.luckysheet_select_save?.[0].column_focus;
+  const selectionRowFocus = ctx.luckysheet_select_save?.[0].row_focus;
+
+  let scrollAmount = Math.max(20, freezeW);
+
+  // Rightward movement of cell/selection
   if (col - scrollLeft - winW + 20 > 0) {
-    ctx.scrollLeft = col - winW + 20;
-  } else if (col_pre - scrollLeft - freezeW < 0) {
-    const scrollAmount = Math.max(20, freezeW);
-    ctx.scrollLeft = col_pre - scrollAmount;
+    // If selection size is shrinking towards right
+    const isShrinking = colRangeEnd === selectionColumnFocus;
+    // If selection is shrinking, then scroll to keep the rightmost cell in selection visible
+    if (isShrinking && colRangeStart && colRangeStart !== colRangeEnd) {
+      const colRangeStart_pre = Math.max(0, colRangeStart - 1);
+      if (colRangeStart_pre < column_focus) ctx.scrollLeft = 0;
+      else
+        ctx.scrollLeft =
+          ctx.visibledatacolumn[colRangeStart_pre] - scrollAmount;
+    }
+    // Otherwise just scroll by fixed amount
+    else ctx.scrollLeft = ctx.visibledatacolumn[frozen ? c + 1 : c] - winW + 20;
+  }
+  // Leftward movement of cell/selection
+  else if (col_pre - scrollLeft - freezeW < 0) {
+    // If selection size is shrinking towards left
+    const isShrinking = colRangeStart === selectionColumnFocus;
+    // If selection is shrinking, then scroll to keep the leftmost cell in selection visible
+    if (
+      isShrinking &&
+      colRangeEnd &&
+      colRangeStart !== colRangeEnd &&
+      ctx.visibledatacolumn[colRangeEnd] < ctx.scrollLeft + winW
+    ) {
+      ctx.scrollLeft =
+        ctx.visibledatacolumn[frozen ? colRangeEnd + 1 : colRangeEnd] -
+        winW +
+        scrollAmount;
+    }
+    // Otherwise just scroll by fixed amount
+    else ctx.scrollLeft = col_pre - scrollAmount;
   }
 
+  scrollAmount = Math.max(20, freezeH);
+
+  // Downward movement of cell/selection
   if (row - scrollTop - winH + 20 > 0) {
-    ctx.scrollTop = row - winH + 20;
-  } else if (row_pre - scrollTop - freezeH < 0) {
-    const scrollAmount = Math.max(20, freezeH);
-    ctx.scrollTop = row_pre - scrollAmount;
+    const isShrinking = rowRangeEnd === selectionRowFocus;
+    // If selection is shrinking, then scroll to keep the topmost cell in selection visible
+    if (isShrinking && rowRangeStart && rowRangeStart !== rowRangeEnd) {
+      const rowRangeStart_pre = Math.max(0, rowRangeStart - 1);
+      // Don't scroll if topmost cell is within frozen range
+      if (rowRangeStart_pre < row_focus) ctx.scrollTop = 0;
+      else ctx.scrollTop = ctx.visibledatarow[rowRangeStart_pre] - scrollAmount;
+    }
+    // Otherwise just scroll by fixed amount
+    else ctx.scrollTop = row - winH + 20;
+  }
+  // Upward movement of cell/selection
+  else if (row_pre - scrollTop - freezeH < 0) {
+    const isShrinking = rowRangeStart === selectionRowFocus;
+
+    // If selection is shrinking, then scroll to keep the bottom most cell in selection visible
+    if (
+      isShrinking &&
+      rowRangeEnd &&
+      rowRangeStart !== rowRangeEnd &&
+      ctx.visibledatarow[rowRangeEnd] < ctx.scrollTop + winH
+    ) {
+      ctx.scrollTop = ctx.visibledatarow[rowRangeEnd] - winH + scrollAmount;
+    }
+    // Otherwise just scroll by fixed amount
+    else {
+      ctx.scrollTop = row_pre - scrollAmount;
+    }
+  } else if (
+    frozen &&
+    rowRangeEnd &&
+    colRangeEnd &&
+    (rowRangeStart !== rowRangeEnd || colRangeStart !== colRangeEnd)
+  ) {
+    if (ctx.visibledatarow[rowRangeEnd] + 20 < scrollTop + winH) {
+      ctx.scrollTop = Math.max(0, ctx.scrollTop - scrollAmount);
+    }
+    if (ctx.visibledatacolumn[colRangeEnd] + 20 < scrollLeft + winW) {
+      ctx.scrollLeft = Math.max(0, ctx.scrollLeft - scrollAmount);
+    }
   }
 }
 

--- a/packages/react/src/components/FilterOption/index.tsx
+++ b/packages/react/src/components/FilterOption/index.tsx
@@ -97,7 +97,7 @@ const FilterOptions: React.FC<{ getContainer: () => HTMLDivElement }> = ({
   return filterOptions == null ? (
     <div />
   ) : (
-    <div>
+    <>
       <div
         id="luckysheet-filter-selected-sheet"
         className="luckysheet-cell-selected luckysheet-filter-selected"
@@ -184,7 +184,7 @@ const FilterOptions: React.FC<{ getContainer: () => HTMLDivElement }> = ({
           </div>
         );
       })}
-    </div>
+    </>
   );
 };
 

--- a/packages/react/src/components/FilterOption/index.tsx
+++ b/packages/react/src/components/FilterOption/index.tsx
@@ -91,8 +91,19 @@ const FilterOptions: React.FC<{ getContainer: () => HTMLDivElement }> = ({
     ]
   );
 
-  const frozenColumns = frozen?.range?.column_focus || -1;
-  const frozenRows = frozen?.range?.row_focus || -1;
+  const freezeType = frozen?.type;
+  let frozenColumns = -1;
+  let frozenRows = -1;
+
+  if (freezeType === "row") frozenRows = 0;
+  else if (freezeType === "column") frozenColumns = 0;
+  else if (freezeType === "both") {
+    frozenColumns = 0;
+    frozenRows = 0;
+  } else {
+    frozenColumns = frozen?.range?.column_focus || -1;
+    frozenRows = frozen?.range?.row_focus || -1;
+  }
 
   return filterOptions == null ? (
     <div />


### PR DESCRIPTION
Resolved #443 

This PR handles the filter range highlight/borders/icons for frozen sheets. The same logic used in selection.ts is applied here to take care of hiding the filters when the scroll causes the rows/columns to be hidden behind the frozen area.

Demo for frozen sheet - 

https://github.com/ruilisi/fortune-sheet/assets/22197708/a974491c-1ed2-4caa-adc3-f0629ec30e79

Demo for non frozen sheet - 


https://github.com/ruilisi/fortune-sheet/assets/22197708/56b4d55a-9214-4c5a-a59a-033360b9b518


