### PR TITLE
fix: just number should be included into calc-selection

### DIFF
--- a/packages/core/src/modules/selection.ts
+++ b/packages/core/src/modules/selection.ts
@@ -2363,9 +2363,13 @@ export function calcSelectionInfo(ctx: Context, lang?: string | null) {
       for (let c = 0; c < data[0].length; c += 1) {
         // 防止选区长度超出data
         if (r >= data.length || c >= data[0].length) break;
+        const ct = data![r][c]?.ct?.t as string;
         const value = data![r][c]?.m as string;
         // 判断是不是数字
-        if (parseFloat(value).toString() !== "NaN") {
+        if (
+          ct === "n" ||
+          (ct === "g" && parseFloat(value).toString() !== "NaN")
+        ) {
           const valueNumber = parseFloat(value);
           count += 1;
           sum += valueNumber;


### PR DESCRIPTION
fix:
   * just number should be included into calc-selection, date, text should not be included
   
<img width="326" alt="image" src="https://github.com/ruilisi/fortune-sheet/assets/82332499/ede382ac-cf9a-4a46-b051-c4755568b764">
