### PR TITLE
Cell drag formula updation fix

### DIFF
--- a/packages/core/src/modules/dropCell.ts
+++ b/packages/core/src/modules/dropCell.ts
@@ -2338,18 +2338,29 @@ export function updateDropCell(ctx: Context) {
         for (let j = apply_str_r; j <= apply_end_r; j += 1) {
           const cell = applyData[j - apply_str_r];
 
-          if (cell?.f != null) {
+          if (cell) {
             const f = `=${formula.functionCopy(
               ctx,
-              cell.f,
+              cell?.f || "",
               "down",
               j - apply_str_r + 1
             )}`;
+
             const v = formula.execfunction(ctx, f, j, i);
 
-            formula.execFunctionGroup(ctx, j, i, v[1], undefined, d);
+            const cellValue = v[1] === "" ? cell.v : v[1];
 
-            [, cell.v, cell.f] = v;
+            formula.execFunctionGroup(ctx, j, i, cellValue, undefined, d);
+
+            cell.v = cellValue;
+
+            const isEmptyFormula = v[2] === "=";
+            if (isEmptyFormula) {
+              cell.f = undefined;
+              cell.m = cellValue?.toString();
+            } else {
+              [, , cell.f] = v;
+            }
 
             if (cell.spl != null) {
               cell.spl = v[3].data;
@@ -2449,18 +2460,29 @@ export function updateDropCell(ctx: Context) {
         for (let j = apply_end_r; j >= apply_str_r; j -= 1) {
           const cell = applyData[apply_end_r - j];
 
-          if (cell?.f != null) {
+          if (cell) {
             const f = `=${formula.functionCopy(
               ctx,
-              cell.f,
+              cell.f || "",
               "up",
               apply_end_r - j + 1
             )}`;
+
             const v = formula.execfunction(ctx, f, j, i);
 
-            formula.execFunctionGroup(ctx, j, i, v[1], undefined, d);
+            const cellValue = v[1] === "" ? cell.v : v[1];
 
-            [, cell.v, cell.f] = v;
+            formula.execFunctionGroup(ctx, j, i, cellValue, undefined, d);
+
+            cell.v = cellValue;
+
+            const isEmptyFormula = v[2] === "=";
+            if (isEmptyFormula) {
+              cell.f = undefined;
+              cell.m = cellValue?.toString();
+            } else {
+              [, , cell.f] = v;
+            }
 
             if (cell.spl != null) {
               cell.spl = v[3].data;
@@ -2556,18 +2578,28 @@ export function updateDropCell(ctx: Context) {
         for (let j = apply_str_c; j <= apply_end_c; j += 1) {
           const cell = applyData[j - apply_str_c];
 
-          if (cell?.f != null) {
+          if (cell) {
             const f = `=${formula.functionCopy(
               ctx,
-              cell.f,
+              cell.f || "",
               "right",
               j - apply_str_c + 1
             )}`;
             const v = formula.execfunction(ctx, f, i, j);
 
-            formula.execFunctionGroup(ctx, j, i, v[1], undefined, d);
+            const cellValue = v[1] === "" ? cell.v : v[1];
 
-            [, cell.v, cell.f] = v;
+            formula.execFunctionGroup(ctx, i, j, cellValue, undefined, d);
+
+            cell.v = cellValue;
+
+            const isEmptyFormula = v[2] === "=";
+            if (isEmptyFormula) {
+              cell.f = undefined;
+              cell.m = cellValue?.toString();
+            } else {
+              [, , cell.f] = v;
+            }
 
             if (cell.spl != null) {
               cell.spl = v[3].data;
@@ -2654,18 +2686,28 @@ export function updateDropCell(ctx: Context) {
         for (let j = apply_end_c; j >= apply_str_c; j -= 1) {
           const cell = applyData[apply_end_c - j];
 
-          if (cell?.f != null) {
+          if (cell) {
             const f = `=${formula.functionCopy(
               ctx,
-              cell.f,
+              cell.f || "",
               "left",
               apply_end_c - j + 1
             )}`;
             const v = formula.execfunction(ctx, f, i, j);
 
-            formula.execFunctionGroup(ctx, j, i, v[1], undefined, d);
+            const cellValue = v[1] === "" ? cell.v : v[1];
 
-            [, cell.v, cell.f] = v;
+            formula.execFunctionGroup(ctx, i, j, cellValue, undefined, d);
+
+            cell.v = cellValue;
+
+            const isEmptyFormula = v[2] === "=";
+            if (isEmptyFormula) {
+              cell.f = undefined;
+              cell.m = cellValue?.toString();
+            } else {
+              [, , cell.f] = v;
+            }
 
             if (cell.spl != null) {
               cell.spl = v[3].data;

--- a/packages/core/src/modules/dropCell.ts
+++ b/packages/core/src/modules/dropCell.ts
@@ -11,6 +11,7 @@ import * as formula from "./formula";
 import { isRealNum } from "./validation";
 import { CFSplitRange } from "./ConditionFormat";
 import { normalizeSelection } from "./selection";
+import { jfrefreshgrid } from "./refresh";
 
 function toPx(v: number) {
   return `${v}px`;
@@ -2338,29 +2339,18 @@ export function updateDropCell(ctx: Context) {
         for (let j = apply_str_r; j <= apply_end_r; j += 1) {
           const cell = applyData[j - apply_str_r];
 
-          if (cell) {
+          if (cell?.f != null) {
             const f = `=${formula.functionCopy(
               ctx,
-              cell?.f || "",
+              cell.f,
               "down",
               j - apply_str_r + 1
             )}`;
-
             const v = formula.execfunction(ctx, f, j, i);
 
-            const cellValue = v[1] === "" ? cell.v : v[1];
+            formula.execFunctionGroup(ctx, j, i, v[1], undefined, d);
 
-            formula.execFunctionGroup(ctx, j, i, cellValue, undefined, d);
-
-            cell.v = cellValue;
-
-            const isEmptyFormula = v[2] === "=";
-            if (isEmptyFormula) {
-              cell.f = undefined;
-              cell.m = cellValue?.toString();
-            } else {
-              [, , cell.f] = v;
-            }
+            [, cell.v, cell.f] = v;
 
             if (cell.spl != null) {
               cell.spl = v[3].data;
@@ -2460,29 +2450,18 @@ export function updateDropCell(ctx: Context) {
         for (let j = apply_end_r; j >= apply_str_r; j -= 1) {
           const cell = applyData[apply_end_r - j];
 
-          if (cell) {
+          if (cell?.f != null) {
             const f = `=${formula.functionCopy(
               ctx,
-              cell.f || "",
+              cell.f,
               "up",
               apply_end_r - j + 1
             )}`;
-
             const v = formula.execfunction(ctx, f, j, i);
 
-            const cellValue = v[1] === "" ? cell.v : v[1];
+            formula.execFunctionGroup(ctx, j, i, v[1], undefined, d);
 
-            formula.execFunctionGroup(ctx, j, i, cellValue, undefined, d);
-
-            cell.v = cellValue;
-
-            const isEmptyFormula = v[2] === "=";
-            if (isEmptyFormula) {
-              cell.f = undefined;
-              cell.m = cellValue?.toString();
-            } else {
-              [, , cell.f] = v;
-            }
+            [, cell.v, cell.f] = v;
 
             if (cell.spl != null) {
               cell.spl = v[3].data;
@@ -2578,28 +2557,18 @@ export function updateDropCell(ctx: Context) {
         for (let j = apply_str_c; j <= apply_end_c; j += 1) {
           const cell = applyData[j - apply_str_c];
 
-          if (cell) {
+          if (cell?.f != null) {
             const f = `=${formula.functionCopy(
               ctx,
-              cell.f || "",
+              cell.f,
               "right",
               j - apply_str_c + 1
             )}`;
             const v = formula.execfunction(ctx, f, i, j);
 
-            const cellValue = v[1] === "" ? cell.v : v[1];
+            formula.execFunctionGroup(ctx, j, i, v[1], undefined, d);
 
-            formula.execFunctionGroup(ctx, i, j, cellValue, undefined, d);
-
-            cell.v = cellValue;
-
-            const isEmptyFormula = v[2] === "=";
-            if (isEmptyFormula) {
-              cell.f = undefined;
-              cell.m = cellValue?.toString();
-            } else {
-              [, , cell.f] = v;
-            }
+            [, cell.v, cell.f] = v;
 
             if (cell.spl != null) {
               cell.spl = v[3].data;
@@ -2686,28 +2655,18 @@ export function updateDropCell(ctx: Context) {
         for (let j = apply_end_c; j >= apply_str_c; j -= 1) {
           const cell = applyData[apply_end_c - j];
 
-          if (cell) {
+          if (cell?.f != null) {
             const f = `=${formula.functionCopy(
               ctx,
-              cell.f || "",
+              cell.f,
               "left",
               apply_end_c - j + 1
             )}`;
             const v = formula.execfunction(ctx, f, i, j);
 
-            const cellValue = v[1] === "" ? cell.v : v[1];
+            formula.execFunctionGroup(ctx, j, i, v[1], undefined, d);
 
-            formula.execFunctionGroup(ctx, i, j, cellValue, undefined, d);
-
-            cell.v = cellValue;
-
-            const isEmptyFormula = v[2] === "=";
-            if (isEmptyFormula) {
-              cell.f = undefined;
-              cell.m = cellValue?.toString();
-            } else {
-              [, , cell.f] = v;
-            }
+            [, cell.v, cell.f] = v;
 
             if (cell.spl != null) {
               cell.spl = v[3].data;
@@ -2825,7 +2784,7 @@ export function updateDropCell(ctx: Context) {
   //   cdformat,
   //   dataVerification,
   // };
-  // jfrefreshgrid(d, ctx.luckysheet_select_save, allParam);
+  jfrefreshgrid(ctx, d, ctx.luckysheet_select_save);
 
   // selectHightlightShow();
 }


### PR DESCRIPTION
Closes #500 

This PR introduces changes to the `dropCell.ts` file to fix the issue of non-updation of formulae upon dragging the value of static cells to other cells. For `left` `right` `up` and `down` drag directions, I have  changed the existing `if` condition to allow running the formula groups even if the dragged cell itself does not have a defined `.f` value. To account for this, I am now conditionally setting the final value and formula of the cell based on whether it has a formula or not.

The existing implementation for `right` and `left` had an unrelated bug as well, where `i` and `j` were used in the incorrect order while calling `formula.execFunctionGroup`. This PR fixes this behaviour as well.

Demos - 

https://github.com/ruilisi/fortune-sheet/assets/22197708/bb0fc36a-a3d9-462b-ab1e-1f130e129bcd


https://github.com/ruilisi/fortune-sheet/assets/22197708/412cffaa-c669-4ae3-9d77-3f26a9f319fb

