### PR TITLE
Check rangeCount before getRangeAt

### DIFF
--- a/packages/core/src/modules/cell.ts
+++ b/packages/core/src/modules/cell.ts
@@ -1224,6 +1224,7 @@ export function isAllSelectedCellsInStatus(
   if (!_.isEmpty(ctx.luckysheetCellUpdate)) {
     const w = window.getSelection();
     if (!w) return false;
+    if (w.rangeCount === 0) return false;
     const range = w.getRangeAt(0);
     if (range.collapsed === true) {
       return false;

--- a/packages/core/src/modules/inline-string.ts
+++ b/packages/core/src/modules/inline-string.ts
@@ -363,6 +363,7 @@ export function updateInlineStringFormat(
   // let s = ctx.inlineStringEditCache;
   const w = window.getSelection();
   if (!w) return;
+  if (w.rangeCount === 0) return;
 
   const range = w.getRangeAt(0);
 


### PR DESCRIPTION
Closes #525 

This was causing issues on Safari which handles getSelection differently. This PR ensures that the sheet wont break on such operations.