### PR TITLE
fix: preserve data verification on paste + update sheet on verification dropdown value change

### DIFF
--- a/packages/core/src/events/paste.ts
+++ b/packages/core/src/events/paste.ts
@@ -1077,10 +1077,7 @@ function pasteHandlerOfCopyPaste(
   // ) {
   //   return;
   // }
-  console.log(
-    ctx.luckysheetfile[getSheetIndex(ctx, ctx.currentSheetId)!]
-      ?.dataVerification
-  );
+  
   const allowEdit = isAllowEdit(ctx);
   if (!allowEdit) return;
 

--- a/packages/core/src/events/paste.ts
+++ b/packages/core/src/events/paste.ts
@@ -1077,6 +1077,10 @@ function pasteHandlerOfCopyPaste(
   // ) {
   //   return;
   // }
+  console.log(
+    ctx.luckysheetfile[getSheetIndex(ctx, ctx.currentSheetId)!]
+      ?.dataVerification
+  );
   const allowEdit = isAllowEdit(ctx);
   if (!allowEdit) return;
 
@@ -1438,7 +1442,7 @@ function pasteHandlerOfCopyPaste(
   const file = ctx.luckysheetfile[getSheetIndex(ctx, ctx.currentSheetId)!];
   file.config = cfg;
   file.luckysheet_conditionformat_save = cdformat;
-  file.dataVerification = dataVerification;
+  file.dataVerification = { ...file.dataVerification, ...dataVerification };
 
   // 若选区内包含超链接
   if (

--- a/packages/core/src/events/paste.ts
+++ b/packages/core/src/events/paste.ts
@@ -1077,7 +1077,6 @@ function pasteHandlerOfCopyPaste(
   // ) {
   //   return;
   // }
-  
   const allowEdit = isAllowEdit(ctx);
   if (!allowEdit) return;
 

--- a/packages/core/src/modules/dataVerification.ts
+++ b/packages/core/src/modules/dataVerification.ts
@@ -13,6 +13,7 @@ import {
   isdatetime,
   isRealNull,
   isRealNum,
+  jfrefreshgrid,
   mergeBorder,
   rowLocationByIndex,
   setCellValue,
@@ -788,6 +789,7 @@ export function setDropcownValue(ctx: Context, value: string, arr: any) {
     ctx.dataVerificationDropDownList = false;
   }
   setCellValue(ctx, rowIndex, colIndex, d, value);
+  jfrefreshgrid(ctx, null, undefined);
 }
 
 // 输入数据验证


### PR DESCRIPTION
Closes #515 
Closes #516 

Existing implementation was overriding the entire data verification object, which is now preserved thru this code change.

Also, now we refresh the grid on verification dropdown value changes.