### PR TITLE
fix: handle refresh and clipboard for paste

### DIFF
--- a/packages/core/src/events/paste.ts
+++ b/packages/core/src/events/paste.ts
@@ -18,6 +18,7 @@ import { expandRowsAndColumns, storeSheetParamALL } from "../modules/sheet";
 import { jfrefreshgrid } from "../modules/refresh";
 import { setRowHeight } from "../api";
 import { CFSplitRange } from "../modules";
+import clipboard from "../modules/clipboard";
 
 function postPasteCut(
   ctx: Context,
@@ -390,6 +391,7 @@ function pasteHandler(ctx: Context, data: any, borderInfo?: any) {
       // jfrefreshgrid(d, ctx.luckysheet_select_save, allParam);
       // selectHightlightShow();
     }
+    jfrefreshgrid(ctx, null, undefined);
   } else {
     data = data.replace(/\r/g, "");
     const dataChe = [];
@@ -496,6 +498,7 @@ function pasteHandler(ctx: Context, data: any, borderInfo?: any) {
     //   jfrefreshgrid(d, ctx.luckysheet_select_save);
     //   selectHightlightShow();
     // }
+    jfrefreshgrid(ctx, null, undefined);
   }
 }
 
@@ -1953,7 +1956,6 @@ export function handlePaste(ctx: Context, e: ClipboardEvent) {
           });
           r += 1;
         });
-
         ctx.luckysheet_selection_range = [];
         pasteHandler(ctx, data, borderInfo);
         // $("#fortune-copy-content").empty();
@@ -1987,9 +1989,15 @@ export function handlePaste(ctx: Context, e: ClipboardEvent) {
   }
 }
 
-export function handlePasteByClick(ctx: Context, triggerType?: string) {
+export function handlePasteByClick(
+  ctx: Context,
+  clipboardData: string,
+  triggerType?: string
+) {
   const allowEdit = isAllowEdit(ctx);
   if (!allowEdit) return;
+
+  if (clipboardData) clipboard.writeHtml(clipboardData);
 
   const textarea = document.querySelector("#fortune-copy-content");
   // textarea.focus();
@@ -1997,7 +2005,7 @@ export function handlePasteByClick(ctx: Context, triggerType?: string) {
 
   // 等50毫秒，keyPress事件发生了再去处理数据
   // setTimeout(function () {
-  const data = textarea?.innerHTML;
+  const data = textarea?.innerHTML || textarea?.textContent;
   if (!data) return;
 
   if (
@@ -2015,7 +2023,7 @@ export function handlePasteByClick(ctx: Context, triggerType?: string) {
   } else if (data.indexOf("fortune-copy-action-image") > -1) {
     // imageCtrl.pasteImgItem();
   } else if (triggerType !== "btn") {
-    // pasteHandler(data);
+    pasteHandler(ctx, data);
   } else {
     // if (isEditMode()) {
     //   alert(local_drag.pasteMustKeybordAlert);

--- a/packages/react/src/components/ContextMenu/index.tsx
+++ b/packages/react/src/components/ContextMenu/index.tsx
@@ -64,9 +64,10 @@ const ContextMenu: React.FC = () => {
         return (
           <Menu
             key={name}
-            onClick={() => {
+            onClick={async () => {
+              const clipboardText = await navigator.clipboard.readText();
               setContext((draftCtx) => {
-                handlePasteByClick(draftCtx);
+                handlePasteByClick(draftCtx, clipboardText);
                 draftCtx.contextMenu = {};
               });
             }}


### PR DESCRIPTION
Closes #512 
Closes #518 

1. Refresh the grid on data being pasted to update formulae
2. Read data from clipboard on right click context menu paste

https://github.com/ruilisi/fortune-sheet/assets/22197708/3b8ecf3c-a44b-4890-89ae-ce7dfdf8ee1c


