### PR TITLE
fix: correctly process ct.s array in getCellValue

### DIFF
--- a/packages/core/src/api/cell.ts
+++ b/packages/core/src/api/cell.ts
@@ -44,7 +44,7 @@ export function getCellValue(
     } else if (cellData && cellData.ct && cellData.ct.fa === "yyyy-MM-dd") {
       ret = cellData.m;
     } else if (cellData.ct?.t === "inlineStr") {
-      ret = cellData.ct.s[0].v;
+      ret = cellData.ct.s.reduce((prev: string, cur: any) => prev + (cur.v ?? ""), "");
     }
   }
 


### PR DESCRIPTION
If a cell's content is composed of parts with different styles, `Cell.ct.s` can be an array with multiple elements. However, current `getCellValue` API only extracts the first content part from `s` array. In order to retrieve full content, values in `s` array should be concatenated.