### PR TITLE
Formula calculation optimisations

### DIFF
--- a/packages/core/src/events/paste.ts
+++ b/packages/core/src/events/paste.ts
@@ -1343,7 +1343,15 @@ function pasteHandlerOfCopyPaste(
               func = `=${functionCopy(ctx, func, "left", Math.abs(offsetCol))}`;
             }
 
-            const funcV = execfunction(ctx, func, h, c, undefined, true);
+            const funcV = execfunction(
+              ctx,
+              func,
+              h,
+              c,
+              undefined,
+              undefined,
+              true
+            );
 
             if (!_.isNil(value.spl)) {
               // value.f = funcV[2];

--- a/packages/core/src/modules/cell.ts
+++ b/packages/core/src/modules/cell.ts
@@ -829,7 +829,7 @@ export function updateCell(
   if (_.isPlainObject(curv)) {
     if (!isCurInline) {
       if (_.isString(value) && value.slice(0, 1) === "=" && value.length > 1) {
-        const v = execfunction(ctx, value, r, c, undefined, true);
+        const v = execfunction(ctx, value, r, c, undefined, undefined, true);
         isRunExecFunction = false;
         curv = _.cloneDeep(d?.[r]?.[c] || {});
         [, curv.v, curv.f] = v;
@@ -859,7 +859,15 @@ export function updateCell(
           valueFunction.slice(0, 1) === "=" &&
           valueFunction.length > 1
         ) {
-          const v = execfunction(ctx, valueFunction, r, c, undefined, true);
+          const v = execfunction(
+            ctx,
+            valueFunction,
+            r,
+            c,
+            undefined,
+            undefined,
+            true
+          );
           isRunExecFunction = false;
           // get v/m/ct
 
@@ -912,7 +920,7 @@ export function updateCell(
     value = curv;
   } else {
     if (_.isString(value) && value.slice(0, 1) === "=" && value.length > 1) {
-      const v = execfunction(ctx, value, r, c, undefined, true);
+      const v = execfunction(ctx, value, r, c, undefined, undefined, true);
       isRunExecFunction = false;
       value = {
         v: v[1],
@@ -941,7 +949,15 @@ export function updateCell(
         valueFunction.slice(0, 1) === "=" &&
         valueFunction.length > 1
       ) {
-        const v = execfunction(ctx, valueFunction, r, c, undefined, true);
+        const v = execfunction(
+          ctx,
+          valueFunction,
+          r,
+          c,
+          undefined,
+          undefined,
+          true
+        );
         isRunExecFunction = false;
         // value = {
         //     "v": v[1],

--- a/packages/core/src/modules/formula.ts
+++ b/packages/core/src/modules/formula.ts
@@ -947,7 +947,8 @@ export function insertUpdateFunctionGroup(
   ctx: Context,
   r: number,
   c: number,
-  id?: string
+  id?: string,
+  calcChainSet?: Set<string>
 ) {
   if (_.isNil(id)) {
     id = ctx.currentSheetId;
@@ -971,14 +972,18 @@ export function insertUpdateFunctionGroup(
     calcChain = [];
   }
 
-  for (let i = 0; i < calcChain.length; i += 1) {
-    const calc = calcChain[i];
-    if (calc.r === r && calc.c === c && calc.id === id) {
-      // server.saveParam("fc", index, calc, {
-      //   op: "update",
-      //   pos: i,
-      // });
-      return;
+  if (calcChainSet) {
+    if (calcChainSet.has(`${r}_${c}_${id}`)) return;
+  } else {
+    for (let i = 0; i < calcChain.length; i += 1) {
+      const calc = calcChain[i];
+      if (calc.r === r && calc.c === c && calc.id === id) {
+        // server.saveParam("fc", index, calc, {
+        //   op: "update",
+        //   pos: i,
+        // });
+        return;
+      }
     }
   }
 
@@ -1003,6 +1008,7 @@ export function execfunction(
   r: number,
   c: number,
   id?: string,
+  calcChainSet?: Set<string>,
   isrefresh?: boolean,
   notInsertFunc?: boolean
 ) {
@@ -1162,7 +1168,7 @@ export function execfunction(
     }
 
     if (!notInsertFunc) {
-      insertUpdateFunctionGroup(ctx, r, c, id);
+      insertUpdateFunctionGroup(ctx, r, c, id, calcChainSet);
     }
   }
 
@@ -1640,6 +1646,11 @@ export function execFunctionGroup(
 
   formulaRunList.reverse();
 
+  const calcChainSet = new Set<string>();
+  calcChains.forEach((item) => {
+    calcChainSet.add(`${item.r}_${item.c}_${item.id}`);
+  });
+
   // console.log(formulaObjects, ii)
   // console.timeEnd("3");
 
@@ -1657,7 +1668,8 @@ export function execFunctionGroup(
       calc_funcStr,
       formulaCell.r,
       formulaCell.c,
-      formulaCell.id
+      formulaCell.id,
+      calcChainSet
     );
 
     ctx.groupValuesRefreshData.push({

--- a/packages/core/src/modules/sort.ts
+++ b/packages/core/src/modules/sort.ts
@@ -94,7 +94,7 @@ export function sortDataRange(
         } else if (moveOffset < 0) {
           func = `=${functionCopy(ctx, func, "up", -moveOffset)}`;
         }
-        const funcV = execfunction(ctx, func, r, c, undefined, true);
+        const funcV = execfunction(ctx, func, r, c, undefined, undefined, true);
         [, cell!.v, cell!.f] = funcV;
         cell.m = update(cell.ct?.fa || "General", cell.v);
       }


### PR DESCRIPTION
Resolves #486

Right now, pasting formulae into sheets is roughly an $O(n^2)$ operation due to the linear search loop on the entire `calcChain` being run for each formula update.

This PR uses a `Set` instead of the `calcChain` array to optimise the search operation into $O(log n)$ - hence converting the entire operation to $O(nlogn)$ more or less. The set is computed only once for the entire operation, which makes paste operations less than ~15 rows more expensive, but for more rows it is many orders of magnitude faster.

Here are my findings for the calculation processing time (blue is the current code in master, red is the code in this branch) -

![image](https://github.com/ruilisi/fortune-sheet/assets/22197708/bb7314c9-615f-4dc7-93dc-bad72ee25e45)