### PR TITLE
Paste handler optimizations

### DIFF
--- a/packages/core/src/events/paste.ts
+++ b/packages/core/src/events/paste.ts
@@ -1691,20 +1691,20 @@ export function handlePaste(ctx: Context, e: ClipboardEvent) {
 
         const index = getSheetIndex(ctx, ctx.currentSheetId);
         if (!_.isNil(index)) {
+          if (_.isNil(ctx.luckysheetfile[index].config)) {
+            ctx.luckysheetfile[index].config = {};
+          }
+          if (_.isNil(ctx.luckysheetfile[index].config!.rowlen)) {
+            ctx.luckysheetfile[index].config!.rowlen = {} as Record<
+              number,
+              number
+            >;
+          }
           const rowHeightList = ctx.luckysheetfile[index].config!.rowlen!;
           _.forEach(trList, (tr) => {
             let c = 0;
             const targetR = ctx.luckysheet_select_save![0].row[0] + r;
 
-            if (_.isNil(ctx.luckysheetfile[index].config)) {
-              ctx.luckysheetfile[index].config = {};
-            }
-            if (_.isNil(ctx.luckysheetfile[index].config!.rowlen)) {
-              ctx.luckysheetfile[index].config!.rowlen = {} as Record<
-                number,
-                number
-              >;
-            }
             const targetRowHeight = !_.isNil(tr.getAttribute("height"))
               ? parseInt(tr.getAttribute("height") as string, 10)
               : null;
@@ -1964,7 +1964,6 @@ export function handlePaste(ctx: Context, e: ClipboardEvent) {
 
             r += 1;
           });
-          // next line is the culprit
           setRowHeight(ctx, rowHeightList);
         }
 


### PR DESCRIPTION
Currently the paste operation was bottlenecked by the usage of `setRowHeight` after every loop iteration. This PR changes this process so that the `rowHeightList` is constructed as the loop is run, but the render is performed only post the loop is done - leading to total paste time of about 1 second as compared to 23 seconds for sheets containing prior data and 5000 rows being pasted.