### PR TITLE
Add handleFormulaStringPaste method

### DIFF
--- a/packages/core/src/events/paste.ts
+++ b/packages/core/src/events/paste.ts
@@ -1527,9 +1527,9 @@ function handleFormulaStringPaste(ctx: Context, formulaStr: string) {
   if (!d) return;
 
   if (!d[r][c]) d[r][c] = {};
-  d[r][c].m = val.toString();
-  d[r][c].v = val;
-  d[r][c].f = formulaStr;
+  d[r][c]!.m = val.toString();
+  d[r][c]!.v = val;
+  d[r][c]!.f = formulaStr;
 }
 
 export function handlePaste(ctx: Context, e: ClipboardEvent) {


### PR DESCRIPTION
This PR adds a new method named `handleFormulaStringPaste` to `paste.ts` for handling formulae being pasted as raw strings by the user.  The behaviour mirrors Google Sheets.