### PR TITLE
Fixed: display value incorrect on pasting

### DIFF
--- a/packages/core/src/events/paste.ts
+++ b/packages/core/src/events/paste.ts
@@ -1375,6 +1375,8 @@ function pasteHandlerOfCopyPaste(
 
               if (!_.isNil(value.ct) && !_.isNil(value.ct.fa)) {
                 value.m = update(value.ct.fa, funcV[1]);
+              } else {
+                value.m = update("General", funcV[1]);
               }
             }
           }


### PR DESCRIPTION
Default condition added if celltype/Format definition does not exist on pasting a cell