### PR TITLE
#605 fixed: copy ignores hidden rows, columns in all cases + linter issues

### DIFF
--- a/packages/core/src/events/paste.ts
+++ b/packages/core/src/events/paste.ts
@@ -1100,11 +1100,6 @@ function pasteHandlerOfCopyPaste(
   const c_c1 = copyRange.copyRange[0].column[0];
   const c_c2 = copyRange.copyRange[0].column[1];
 
-  const isSingleCellPaste =
-    copyRange.copyRange.length === 1 &&
-    copyRange.copyRange[0].row[0] === copyRange.copyRange[0].row[1] &&
-    copyRange.copyRange[0].column[0] === copyRange.copyRange[0].column[1];
-
   let arr: CellMatrix = [];
   let isSameRow = false;
   for (let i = 0; i < copyRange.copyRange.length; i += 1) {
@@ -1231,9 +1226,7 @@ function pasteHandlerOfCopyPaste(
   let maxrowCache = 0;
 
   const file = ctx.luckysheetfile[getSheetIndex(ctx, ctx.currentSheetId)!];
-  let hiddenRows;
-  if (isSingleCellPaste)
-    hiddenRows = new Set(Object.keys(file.config?.rowhidden || {}));
+  const hiddenRows = new Set(Object.keys(file.config?.rowhidden || {}));
 
   for (let th = 1; th <= timesH; th += 1) {
     for (let tc = 1; tc <= timesC; tc += 1) {
@@ -1249,7 +1242,7 @@ function pasteHandlerOfCopyPaste(
       const offsetMC: any = {};
       for (let h = mth; h < maxrowCache; h += 1) {
         // skip if row is hidden
-        if (isSingleCellPaste && hiddenRows?.has(h.toString())) continue;
+        if (hiddenRows?.has(h.toString())) continue;
         const x = d[h];
 
         for (let c = mtc; c < maxcellCahe; c += 1) {

--- a/packages/core/src/events/paste.ts
+++ b/packages/core/src/events/paste.ts
@@ -1227,6 +1227,7 @@ function pasteHandlerOfCopyPaste(
 
   const file = ctx.luckysheetfile[getSheetIndex(ctx, ctx.currentSheetId)!];
   const hiddenRows = new Set(Object.keys(file.config?.rowhidden || {}));
+  const hiddenCols = new Set(Object.keys(file.config?.colhidden || {}));
 
   for (let th = 1; th <= timesH; th += 1) {
     for (let tc = 1; tc <= timesC; tc += 1) {
@@ -1246,6 +1247,7 @@ function pasteHandlerOfCopyPaste(
         const x = d[h];
 
         for (let c = mtc; c < maxcellCahe; c += 1) {
+          if (hiddenCols?.has(c.toString())) continue;
           if (
             borderInfoCompute[`${c_r1 + h - mth}_${c_c1 + c - mtc}`] &&
             !borderInfoCompute[`${c_r1 + h - mth}_${c_c1 + c - mtc}`].s

--- a/packages/core/src/modules/dropCell.ts
+++ b/packages/core/src/modules/dropCell.ts
@@ -2287,6 +2287,7 @@ export function updateDropCell(ctx: Context) {
   if (index == null) return;
   const file = ctx.luckysheetfile[index];
   const hiddenRows = new Set(Object.keys(file.config?.rowhidden || {}));
+  const hiddenCols = new Set(Object.keys(file.config?.colhidden || {}));
 
   const cfg = _.cloneDeep(ctx.config);
   if (cfg.borderInfo == null) {
@@ -2332,6 +2333,7 @@ export function updateDropCell(ctx: Context) {
     const asLen = apply_end_r - apply_str_r + 1;
 
     for (let i = apply_str_c; i <= apply_end_c; i += 1) {
+      if (hiddenCols.has(`${i}`)) continue;
       const copyD = copyData[i - apply_str_c];
 
       const applyData = getApplyData(copyD, csLen, asLen);
@@ -2559,6 +2561,7 @@ export function updateDropCell(ctx: Context) {
 
       if (direction === "right") {
         for (let j = apply_str_c; j <= apply_end_c; j += 1) {
+          if (hiddenCols.has(`${j}`)) continue;
           const cell = applyData[j - apply_str_c];
 
           if (cell?.f != null) {
@@ -2657,6 +2660,7 @@ export function updateDropCell(ctx: Context) {
       }
       if (direction === "left") {
         for (let j = apply_end_c; j >= apply_str_c; j -= 1) {
+          if (hiddenCols.has(`${j}`)) continue;
           const cell = applyData[apply_end_c - j];
 
           if (cell?.f != null) {

--- a/packages/react/src/components/ContextMenu/FilterMenu.tsx
+++ b/packages/react/src/components/ContextMenu/FilterMenu.tsx
@@ -379,7 +379,7 @@ const FilterMenu: React.FC = () => {
       }
       _.set(draftCtx, "filterContextMenu.listBoxMaxHeight", containerH);
     });
-  }, [filterContextMenu, setContext]);
+  }, [filterContextMenu, refs.workbookContainer, setContext]);
 
   useLayoutEffect(() => {
     if (!subMenuPos) return;

--- a/packages/react/src/components/ContextMenu/index.tsx
+++ b/packages/react/src/components/ContextMenu/index.tsx
@@ -675,7 +675,7 @@ const ContextMenu: React.FC = () => {
         draftCtx.contextMenu.y = top;
       });
     }
-  }, [contextMenu.x, contextMenu.y, setContext]);
+  }, [contextMenu.x, contextMenu.y, refs.workbookContainer, setContext]);
 
   if (_.isEmpty(context.contextMenu)) return null;
 

--- a/packages/react/src/components/FilterOption/index.tsx
+++ b/packages/react/src/components/FilterOption/index.tsx
@@ -9,9 +9,7 @@ import React, { useCallback, useContext, useEffect } from "react";
 import WorkbookContext from "../../context";
 import SVGIcon from "../SVGIcon";
 
-const FilterOptions: React.FC<{ getContainer: () => HTMLDivElement }> = ({
-  getContainer,
-}) => {
+const FilterOptions: React.FC<{}> = () => {
   const { context, setContext, refs } = useContext(WorkbookContext);
   const {
     filterOptions,
@@ -77,14 +75,7 @@ const FilterOptions: React.FC<{ getContainer: () => HTMLDivElement }> = ({
         };
       });
     },
-    [
-      filterOptions,
-      getContainer,
-      refs.scrollbarX,
-      refs.scrollbarY,
-      refs.workbookContainer,
-      setContext,
-    ]
+    [filterOptions, refs.scrollbarX, refs.scrollbarY, setContext]
   );
 
   const freezeType = frozen?.type;

--- a/packages/react/src/components/Workbook/index.tsx
+++ b/packages/react/src/components/Workbook/index.tsx
@@ -568,6 +568,7 @@ const Workbook = React.forwardRef<WorkbookInstance, Settings & AdditionalProps>(
       mergedSettings.rowHeaderWidth,
       mergedSettings.columnHeaderHeight,
       mergedSettings.addRows,
+      mergedSettings.currency,
     ]);
 
     const onKeyDown = useCallback(


### PR DESCRIPTION
1. Issue #605 fixed, tested in different scenarios - singleCell check not needed.
2. Ignore hidden columns as well 
3. lint issues fixed

Note: In Google Sheets, hidden rows and filtered rows behave differently, in fortunesheet its treated the same. 
In Sheets, on pasting, filtered rows are ignored but hidden rows are not.