### PR TITLE
check for globalThis.

### DIFF
--- a/packages/core/src/context.ts
+++ b/packages/core/src/context.ts
@@ -227,7 +227,7 @@ export function defaultContext(refs: RefValues): Context {
     defaultrowNum: 84,
     addDefaultRows: 50,
     fullscreenmode: true,
-    devicePixelRatio: (globalThis || window).devicePixelRatio,
+    devicePixelRatio: (typeof globalThis !== 'undefined' ? globalThis : typeof window !== 'undefined' ? window : {}).devicePixelRatio,
 
     contextMenu: {},
     sheetTabContextMenu: {},

--- a/packages/react/src/components/Sheet/index.tsx
+++ b/packages/react/src/components/Sheet/index.tsx
@@ -30,7 +30,7 @@ const Sheet: React.FC<Props> = ({ sheet }) => {
       if (!data) return;
       setContext((draftCtx) => {
         if (settings.devicePixelRatio === 0) {
-          draftCtx.devicePixelRatio = (globalThis || window).devicePixelRatio;
+          draftCtx.devicePixelRatio = (typeof globalThis !== 'undefined' ? globalThis : typeof window !== 'undefined' ? window : {}).devicePixelRatio;
         }
         updateContextWithSheetData(draftCtx, data);
         updateContextWithCanvas(


### PR DESCRIPTION
Since browsers do not have globalThis attribute this will cause some problems, I fixed the problem by providing a small check, for typescript compilation this shouldn't affect current behaviour, but for browsers this will make fortune-sheet importable :)

globalThis error should not be handled by vite otherwise creates dependency there

