### PR TITLE
Optimize inline textwrap processing

### DIFF
--- a/packages/core/src/modules/text.ts
+++ b/packages/core/src/modules/text.ts
@@ -1649,6 +1649,8 @@ export function getCellTextInfo(
           }
 
           cumWordHeight += size.height;
+          // stop processing if rest of the cell isnt visible
+          if (cumWordHeight >= cellHeight) break;
         }
       }
 


### PR DESCRIPTION
This PR breaks the loop for `tb === 2` condition with inline text if the text is below the visible area. Not 100% sure if this is going to fix the lag in all scenarios but worth a try. 

Resolves #610 