### PR TITLE
added: batch API, calculateFormula API improvements

### DIFF
--- a/packages/react/src/components/Workbook/api.ts
+++ b/packages/react/src/components/Workbook/api.ts
@@ -36,6 +36,10 @@ export function generateAPIs(
   scrollbarX: HTMLDivElement | null,
   scrollbarY: HTMLDivElement | null
 ) {
+  type ApiCall = {
+    name: string;
+    args: any[];
+  };
   return {
     applyOp: (ops: Op[]) => {
       setContext(
@@ -311,7 +315,7 @@ export function generateAPIs(
     calculateFormula: () => {
       setContext((draftCtx) => {
         _.forEach(draftCtx.luckysheetfile, (sheet_obj) => {
-          api.calculateSheetFromula(draftCtx, sheet_obj.id as string);
+          api.calculateFormula(draftCtx, sheet_obj.id as string);
         });
       });
     },
@@ -326,6 +330,19 @@ export function generateAPIs(
       colCount?: number
     ) => {
       return api.celldataToData(celldata, rowCount, colCount);
+    },
+
+    batchCallApis: (apiCalls: ApiCall[]) => {
+      setContext((draftCtx) => {
+        apiCalls.forEach((apiCall) => {
+          const { name, args } = apiCall;
+          if (typeof (api as any)[name] === "function") {
+            (api as any)[name](draftCtx, ...args);
+          } else {
+            console.warn(`API ${name} does not exist`);
+          }
+        });
+      });
     },
   };
 }


### PR DESCRIPTION
* This PR will enable single undo/redo for multiple API calls
* batchCallApis does not call the exported APIs, instead calls those internal APIs which the exported APIs calls. So the name of export and internal APIs must be same. For example - in this PR, I had to change name of calculateSheetFormula to calculateFormula, so that it's obvious to users what name to pass in argument. Hence, APIs like addPresences and removePresences are not be supported by batchCallApis()