### PR TITLE
added fallback for clipboard copy and context menu paste

### DIFF
--- a/packages/core/src/modules/clipboard.ts
+++ b/packages/core/src/modules/clipboard.ts
@@ -18,6 +18,11 @@ export default class clipboard {
       ele.focus({ preventScroll: true });
       document.execCommand("selectAll");
       document.execCommand("copy");
+      
+      // Fallback setup
+      const plainText = ele.innerText || ele.textContent || ""; // In order to match the clipboard which only stores the visible text without formatting
+      sessionStorage.setItem("localClipboard", plainText); // Also store in sessionStorage for fallback access
+
       setTimeout(() => {
         ele?.blur();
         previouslyFocusedElement?.focus?.();

--- a/packages/core/src/modules/clipboard.ts
+++ b/packages/core/src/modules/clipboard.ts
@@ -18,7 +18,7 @@ export default class clipboard {
       ele.focus({ preventScroll: true });
       document.execCommand("selectAll");
       document.execCommand("copy");
-      
+
       // Fallback setup
       const plainText = ele.innerText || ele.textContent || ""; // In order to match the clipboard which only stores the visible text without formatting
       sessionStorage.setItem("localClipboard", plainText); // Also store in sessionStorage for fallback access

--- a/packages/react/src/components/ContextMenu/index.tsx
+++ b/packages/react/src/components/ContextMenu/index.tsx
@@ -67,12 +67,15 @@ const ContextMenu: React.FC = () => {
             key={name}
             onClick={async () => {
               let clipboardText = "";
-              let sessionClipboardText = sessionStorage.getItem("localClipboard") || "";
+              const sessionClipboardText =
+                sessionStorage.getItem("localClipboard") || "";
 
               try {
                 clipboardText = await navigator.clipboard.readText();
               } catch (err) {
-                console.warn("Clipboard access blocked. Attempting to use sessionStorage fallback.");
+                console.warn(
+                  "Clipboard access blocked. Attempting to use sessionStorage fallback."
+                );
               }
 
               const finalText = clipboardText || sessionClipboardText;

--- a/packages/react/src/components/ContextMenu/index.tsx
+++ b/packages/react/src/components/ContextMenu/index.tsx
@@ -66,9 +66,19 @@ const ContextMenu: React.FC = () => {
           <Menu
             key={name}
             onClick={async () => {
-              const clipboardText = await navigator.clipboard.readText();
+              let clipboardText = "";
+              let sessionClipboardText = sessionStorage.getItem("localClipboard") || "";
+
+              try {
+                clipboardText = await navigator.clipboard.readText();
+              } catch (err) {
+                console.warn("Clipboard access blocked. Attempting to use sessionStorage fallback.");
+              }
+
+              const finalText = clipboardText || sessionClipboardText;
+
               setContext((draftCtx) => {
-                handlePasteByClick(draftCtx, clipboardText);
+                handlePasteByClick(draftCtx, finalText);
                 draftCtx.contextMenu = {};
               });
             }}


### PR DESCRIPTION
This PR is about addressing context menu paste when clipboard access is limited.
Related issue: https://github.com/ruilisi/fortune-sheet/issues/672

To test, run `yarn dev` and stay within the default view and do not open the canvas in a new tab or fullscreen, you want to rely on the storybook iframe to require the permissions. Manage Clipboard access for the current site / domain in your browser to toggle permission and test with both to ensure the copy is completed irrespectively. 