### PR TITLE
feat: add optional sheetId param to addSheet

### DIFF
--- a/packages/react/src/components/Workbook/api.ts
+++ b/packages/react/src/components/Workbook/api.ts
@@ -260,7 +260,18 @@ export function generateAPIs(
     getSheet: (options: api.CommonOptions = {}) =>
       api.getSheetWithLatestCelldata(context, options),
 
-    addSheet: () => setContext((draftCtx) => api.addSheet(draftCtx, settings)),
+    addSheet: (sheetId?: string) => {
+      const existingSheetIds = api
+        .getAllSheets(context)
+        .map((sheet) => sheet.id || "");
+      if (sheetId && existingSheetIds.includes(sheetId)) {
+        console.error(
+          `Failed to add new sheet: A sheet with the id "${sheetId}" already exists. Please use a unique sheet id.`
+        );
+      } else {
+        setContext((draftCtx) => api.addSheet(draftCtx, settings, sheetId));
+      }
+    },
 
     deleteSheet: (options: api.CommonOptions = {}) =>
       setContext((draftCtx) => api.deleteSheet(draftCtx, options)),


### PR DESCRIPTION
Closes https://github.com/ruilisi/fortune-sheet/issues/674

Usage - `ref.current?.addSheet("your sheet id");`

Won't add a sheet and logs an error in the console if a duplicate id is used.