### PR TITLE
Fix/dropdown race condition

### DIFF
--- a/packages/react/src/components/DataVerification/DropdownList.tsx
+++ b/packages/react/src/components/DataVerification/DropdownList.tsx
@@ -6,6 +6,7 @@ import {
   mergeBorder,
   setDropcownValue,
 } from "@fortune-sheet/core";
+
 import React, {
   useCallback,
   useContext,
@@ -13,10 +14,12 @@ import React, {
   useRef,
   useState,
 } from "react";
+
 import WorkbookContext from "../../context";
 import { useOutsideClick } from "../../hooks/useOutsideClick";
 import SVGIcon from "../SVGIcon";
 import "./index.css";
+
 const DropDownList: React.FC = () => {
   const { context, setContext } = useContext(WorkbookContext);
   const containerRef = useRef<HTMLDivElement>(null);
@@ -24,12 +27,15 @@ const DropDownList: React.FC = () => {
   const [isMul, setIsMul] = useState<boolean>(false);
   const [position, setPosition] = useState<{ left: number; top: number }>();
   const [selected, setSelected] = useState<any[]>([]);
+  
   const close = useCallback(() => {
     setContext((ctx) => {
       ctx.dataVerificationDropDownList = false;
     });
   }, [setContext]);
+  
   useOutsideClick(containerRef, close, [close]);
+  
   // 初始化
   useEffect(() => {
     if (!context.luckysheet_select_save) return;
@@ -53,6 +59,7 @@ const DropDownList: React.FC = () => {
     const dropdownList = getDropdownList(context, item.value1);
     // 初始化多选的下拉列表
     const cellValue = getCellValue(rowIndex, colIndex, d);
+    
     if (cellValue) {
       setSelected(cellValue.toString().split(","));
     }
@@ -64,6 +71,7 @@ const DropDownList: React.FC = () => {
     setIsMul(item.type2 === "true");
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
+  
   // 设置下拉列表的值
   useEffect(() => {
     if (!context.luckysheet_select_save) return;
@@ -82,8 +90,10 @@ const DropDownList: React.FC = () => {
     if (cellValue) {
       setSelected(cellValue.toString().split(","));
     }
+    
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [context.luckysheetfile]);
+  
   return (
     <div
       id="luckysheet-dataVerification-dropdown-List"

--- a/packages/react/src/components/DataVerification/DropdownList.tsx
+++ b/packages/react/src/components/DataVerification/DropdownList.tsx
@@ -16,9 +16,7 @@ import React, {
 import WorkbookContext from "../../context";
 import { useOutsideClick } from "../../hooks/useOutsideClick";
 import SVGIcon from "../SVGIcon";
-
 import "./index.css";
-
 const DropDownList: React.FC = () => {
   const { context, setContext } = useContext(WorkbookContext);
   const containerRef = useRef<HTMLDivElement>(null);
@@ -26,15 +24,12 @@ const DropDownList: React.FC = () => {
   const [isMul, setIsMul] = useState<boolean>(false);
   const [position, setPosition] = useState<{ left: number; top: number }>();
   const [selected, setSelected] = useState<any[]>([]);
-
   const close = useCallback(() => {
     setContext((ctx) => {
       ctx.dataVerificationDropDownList = false;
     });
   }, [setContext]);
-
   useOutsideClick(containerRef, close, [close]);
-
   // 初始化
   useEffect(() => {
     if (!context.luckysheet_select_save) return;
@@ -58,7 +53,6 @@ const DropDownList: React.FC = () => {
     const dropdownList = getDropdownList(context, item.value1);
     // 初始化多选的下拉列表
     const cellValue = getCellValue(rowIndex, colIndex, d);
-
     if (cellValue) {
       setSelected(cellValue.toString().split(","));
     }
@@ -70,7 +64,6 @@ const DropDownList: React.FC = () => {
     setIsMul(item.type2 === "true");
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
-
   // 设置下拉列表的值
   useEffect(() => {
     if (!context.luckysheet_select_save) return;
@@ -89,10 +82,8 @@ const DropDownList: React.FC = () => {
     if (cellValue) {
       setSelected(cellValue.toString().split(","));
     }
-
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [context.luckysheetfile]);
-
   return (
     <div
       id="luckysheet-dataVerification-dropdown-List"
@@ -111,15 +102,20 @@ const DropDownList: React.FC = () => {
           key={i}
           onClick={() => {
             setContext((ctx) => {
-              const arr = selected;
+              const arr = [...selected];
               const index = arr.indexOf(v);
               if (index < 0) {
                 arr.push(v);
               } else {
                 arr.splice(index, 1);
               }
-              setSelected(arr);
+              // setSelected(arr); // REMOVED: Redundant update causing race condition
               setDropcownValue(ctx, v, arr);
+              
+              // ADDED: Auto-close for single select
+              if (!isMul) {
+                ctx.dataVerificationDropDownList = false;
+              }
             });
           }}
           tabIndex={0}


### PR DESCRIPTION
This PR fixes a "Cannot update a component while rendering a different component" error and a race condition that occurs when selecting an item from the dropdown.

**Changes**:

1. Removed direct mutation of the `selected` state array.
2. Removed the redundant `setSelected` call inside the `setContext` recipe (which was causing the React warning).
3. Added logic to automatically close the dropdown (`dataVerificationDropDownList = false`) when in single-select mode, ensuring it unmounts immediately after selection.

The original code mutated the state directly and failed to close the dropdown in single-select mode:
```
// BEFORE
onClick: function onClick() {
  setContext(function (ctx) {
    var arr = selected; // Direct reference to state
    // ... mutation ...
    arr.push(v);
    // ...
    setSelected(arr); // Redundant state update inside render cycle
    setDropcownValue(ctx, v, arr);
  });
}
```

The patched code clones the array and handles unmounting:

```
// AFTER
onClick: function onClick() {
  setContext(function (ctx) {
    var arr = [].concat(selected); // Clone array
    // ... mutation ...
    arr.push(v);
    // ...
    // setSelected(arr); // Removed
    setDropcownValue(ctx, v, arr);
    
    // Auto-close for single select
    if (!isMul) {
      ctx.dataVerificationDropDownList = false;
    }
  });
}
```

AFAIK `setContext` uses Immer to produce the next state. The callback function passed to it is effectively a reducer. Calling a React state setter (`setSelected`) inside a reducer or state updater function is a violation of React's purity rules and explains the 'Cannot update component while rendering another' error.

> **Note on Multi-select UX**: I removed the `setSelected` call because it was causing a side-effect inside the `setContext` reducer. I verified that the `useEffect` hook correctly syncs the local state with the global context, and the checkmark updates appear responsive in testing.