### PR TITLE
fix: fix mobile touch scroll acceleration bug

### DIFF
--- a/packages/core/src/modules/mobile.ts
+++ b/packages/core/src/modules/mobile.ts
@@ -36,10 +36,10 @@ export function handleOverlayTouchMove(
     if (!globalCache.touchMoveStartPos) return;
     const slideX = touch.pageX - globalCache.touchMoveStartPos.x;
     const slideY = touch.pageY - globalCache.touchMoveStartPos.y;
-    let { scrollLeft } = ctx;
-    let { scrollTop } = ctx;
-    scrollLeft -= slideX;
-    scrollTop -= slideY;
+    globalCache.touchMoveStartPos.x = touch.pageX;
+    globalCache.touchMoveStartPos.y = touch.pageY;
+    const scrollLeft = scrollbarX.scrollLeft - slideX;
+    const scrollTop = scrollbarY.scrollTop - slideY;
     scrollbarY.scrollTop = scrollTop;
 
     globalCache.touchMoveStartPos.vy_y = slideY;


### PR DESCRIPTION
## Problem

When swiping on mobile (or Chrome DevTools touch mode), the scroll
accelerates the longer you swipe, and continues scrolling even after
the finger stops moving.

## Root Cause

In `handleOverlayTouchMove`, two issues caused cumulative scroll drift:

1. `touchMoveStartPos.x/y` was never updated after the initial touch,
   so `slideX/Y` kept growing relative to the original touch position
   instead of the previous frame.
2. Scroll position was read from `ctx.scrollLeft/Top` (React async state),
   which may not reflect the actual current DOM scroll position.

## Fix

- Update `touchMoveStartPos.x/y` on every `touchmove` event so delta
  is calculated relative to the previous frame (not the initial touch).
- Read scroll position from `scrollbarX.scrollLeft` / `scrollbarY.scrollTop`
  (actual DOM values) instead of `ctx.scrollLeft/Top`.